### PR TITLE
Buildfix for all big endian platforms.

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -52,7 +52,7 @@ else ifeq ($(platform), osx)
 	TARGET := $(TARGET_NAME)_libretro.dylib
 	fpic := -fPIC
 	SHARED := -dynamiclib
-	ifneq ($(arch),ppc)
+	ifeq ($(arch),ppc)
 		ENDIANNESS_DEFINES = -DMSB_FIRST
 	endif
 	CFLAGS += -DHAVE_ASPRINTF
@@ -108,6 +108,7 @@ else ifeq ($(platform), ps3)
 	CC = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-gcc.exe
 	AR = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-ar.exe
 	PLATFORM_DEFINES := -D__CELLOS_LV2
+	ENDIANNESS_DEFINES = -DMSB_FIRST
 	STATIC_LINKING = 1
 	EXTERNAL_ZLIB = 1
 
@@ -117,6 +118,7 @@ else ifeq ($(platform), sncps3)
 	CC = $(CELL_SDK)/host-win32/sn/bin/ps3ppusnc.exe
 	AR = $(CELL_SDK)/host-win32/sn/bin/ps3snarl.exe
 	PLATFORM_DEFINES := -D__CELLOS_LV2
+	ENDIANNESS_DEFINES = -DMSB_FIRST
 	STATIC_LINKING = 1
 	EXTERNAL_ZLIB = 1
 
@@ -160,6 +162,7 @@ else ifeq ($(platform), psl1ght)
 	CC = $(PS3DEV)/ppu/bin/ppu-gcc$(EXE_EXT)
 	AR = $(PS3DEV)/ppu/bin/ppu-ar$(EXE_EXT)
 	PLATFORM_DEFINES := -D__CELLOS_LV2 -DHAVE_ASPRINTF
+	ENDIANNESS_DEFINES = -DMSB_FIRST
 	STATIC_LINKING = 1
 	EXTERNAL_ZLIB = 1
 
@@ -169,6 +172,7 @@ else ifeq ($(platform), xenon)
 	CC = xenon-gcc$(EXE_EXT)
 	AR = xenon-ar$(EXE_EXT)
 	PLATFORM_DEFINES := -D__LIBXENON__
+	ENDIANNESS_DEFINES = -DMSB_FIRST
 	CFLAGS += -DHAVE_ASPRINTF
 	STATIC_LINKING = 1
 	EXTERNAL_ZLIB = 1
@@ -179,6 +183,7 @@ else ifeq ($(platform), ngc)
 	CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
 	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
 	PLATFORM_DEFINES := -DGEKKO -DHW_DOL -mrvl -mcpu=750 -meabi -mhard-float
+	ENDIANNESS_DEFINES = -DMSB_FIRST
 	CFLAGS += -DHAVE_ASPRINTF
 	STATIC_LINKING = 1
 	EXTERNAL_ZLIB = 1
@@ -189,6 +194,7 @@ else ifeq ($(platform), wii)
 	CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
 	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
 	PLATFORM_DEFINES := -DGEKKO -DHW_RVL -mrvl -mcpu=750 -meabi -mhard-float
+	ENDIANNESS_DEFINES = -DMSB_FIRST
 	CFLAGS += -DHAVE_ASPRINTF
 	STATIC_LINKING = 1
 	EXTERNAL_ZLIB = 1


### PR DESCRIPTION
Added -DMSB_FIRST to Makefile.libretro.
Fixes corrupted sprites.