### PR TITLE
Aspect ratio and overscan changes

### DIFF
--- a/src/drivers/libretro/libretro.c
+++ b/src/drivers/libretro/libretro.c
@@ -696,6 +696,7 @@ static void check_variables(void)
    static int overclock_state = -1;
    struct retro_variable var = {0};
    struct retro_system_av_info av_info;
+   bool geometry_update = false;
 
    var.key = "fceumm_palette";
 
@@ -792,24 +793,31 @@ static void check_variables(void)
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      if (!strcmp(var.value, "enabled"))
-         use_overscan = false;
-      else if(!strcmp(var.value, "disabled"))
-         use_overscan = true;
+      bool newval = (!strcmp(var.value, "disabled"));
+      if (newval != use_overscan)
+      {
+         use_overscan = newval;
+         geometry_update = true;
+      }
    }
 
    var.key = "fceumm_aspect";
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      if (!strcmp(var.value, "8:7 PAR"))
-         use_par = true;
-      else if(!strcmp(var.value, "4:3"))
-         use_par = false;
+      bool newval = (!strcmp(var.value, "8:7 PAR"));
+      if (newval != use_par)
+      {
+         use_par = newval;
+         geometry_update = true;
+      }
    }
 
-   retro_get_system_av_info(&av_info);
-   environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &av_info);
+   if (geometry_update)
+   {
+      retro_get_system_av_info(&av_info);
+      environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &av_info);
+   }
 }
 
 /*

--- a/src/drivers/libretro/libretro.c
+++ b/src/drivers/libretro/libretro.c
@@ -548,6 +548,7 @@ void retro_set_environment(retro_environment_t cb)
       { "fceumm_palette", "Color Palette; asqrealc|loopy|quor|chris|matt|pasofami|crashman|mess|zaphod-cv|zaphod-smb|vs-drmar|vs-cv|vs-smb|nintendo-vc|yuv-v3|unsaturated-v5|sony-cxa2025as-us|pal|raw" },
       { "fceumm_nospritelimit", "No Sprite Limit; disabled|enabled" },
       { "fceumm_overclocking", "Overclocking; disabled|2x" },
+      { "fceumm_overscan", "Crop Overscan; enabled|disabled" },
       { NULL, NULL },
    };
 
@@ -689,6 +690,7 @@ static void check_variables(void)
 {
    static int overclock_state = -1;
    struct retro_variable var = {0};
+   struct retro_system_av_info av_info;
 
    var.key = "fceumm_palette";
 
@@ -780,6 +782,19 @@ static void check_variables(void)
          FCEU_InitVirtualVideo();
       }
    }
+
+   var.key = "fceumm_overscan";
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "enabled"))
+         use_overscan = false;
+      else if(!strcmp(var.value, "disabled"))
+         use_overscan = true;
+   }
+
+   retro_get_system_av_info(&av_info);
+   environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &av_info);
 }
 
 /*
@@ -1412,9 +1427,6 @@ bool retro_load_game(const struct retro_game_info *game)
 
    FCEUD_SoundToggle();
    check_variables();
-
-   if (!environ_cb(RETRO_ENVIRONMENT_GET_OVERSCAN, &use_overscan))
-      use_overscan = true;
 
    FCEUI_DisableFourScore(1);
 

--- a/src/drivers/libretro/libretro.c
+++ b/src/drivers/libretro/libretro.c
@@ -572,7 +572,7 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
    info->geometry.base_height = height;
    info->geometry.max_width = width;
    info->geometry.max_height = height;
-   info->geometry.aspect_ratio = 4.0 / 3.0;
+   info->geometry.aspect_ratio = (width * (8.0 / 7.0)) / height;
    info->timing.sample_rate = 32050.0;
    if (FSettings.PAL)
       info->timing.fps = 838977920.0/16777215.0;


### PR DESCRIPTION
Made core provided aspect ratio always have 8:7 PAR according to http://wiki.nesdev.com/w/index.php/Overscan
Fixes https://github.com/libretro/libretro-fceumm/issues/40 and https://github.com/libretro/RetroArch/issues/2837

Made crop overscan into a runtime core option, and use RETRO_ENVIRONMENT_SET_GEOMETRY to keep the aspect ratio and integer scale updated.