### PR TITLE
Perform input poll before running emulator. Reduces input lag by one full frame

### DIFF
--- a/src/drivers/libretro/libretro.c
+++ b/src/drivers/libretro/libretro.c
@@ -995,8 +995,8 @@ void retro_run(void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)
       check_variables();
 
-   FCEUI_Emulate(&gfx, &sound, &ssize, 0);   
-	FCEUD_UpdateInput();
+   FCEUD_UpdateInput();
+   FCEUI_Emulate(&gfx, &sound, &ssize, 0);
 
    for (i = 0; i < ssize; i++)
       sound[i] = (sound[i] << 16) | (sound[i] & 0xffff);


### PR DESCRIPTION
For some reason (no reason?), the current libretro implementation polls input _after_ running the emulator. This means that a whole frame of input lag is added at all times. By simply moving the input poll function call to before running the emulator, we ensure that the emulator runs with freshly polled input instead of what was read 16.67 ms ago.

I've tested the fix and it does indeed have the expected effect, i.e. it reduces input lag by one frame. Since nothing in the actual emulation is changed, I have a hard time seeing how this change could have any side effects. It should be mentioned that with this fix, fceumm is brought up to parity with Nestopia in terms of input lag.

Issue previously reported here: https://github.com/libretro/libretro-fceumm/issues/45