### PR TITLE
Add the more common UNIF extension

### DIFF
--- a/src/drivers/libretro/libretro.c
+++ b/src/drivers/libretro/libretro.c
@@ -600,7 +600,7 @@ void retro_set_environment(retro_environment_t cb)
 void retro_get_system_info(struct retro_system_info *info)
 {
    info->need_fullpath = true;
-   info->valid_extensions = "fds|nes|unif";
+   info->valid_extensions = "fds|nes|unf|unif";
    info->library_version = "(SVN)";
    info->library_name = "FCEUmm";
    info->block_extract = false;


### PR DESCRIPTION
GoodNES doesn't use .unif at all.