### PR TITLE
More palettes

### DIFF
--- a/src/drivers/libretro/libretro.c
+++ b/src/drivers/libretro/libretro.c
@@ -178,7 +178,7 @@ FILE *FCEUD_UTF8fopen(const char *n, const char *m)
 #define MAX_PATH 1024
 
 /*palette for FCEU*/
-#define MAXPAL 22
+#define MAXPAL 23
 
 struct st_palettes {
 	char name[32];
@@ -582,7 +582,25 @@ struct st_palettes palettes[] = {
 		   0xFBFBFB, 0xBFD4FA, 0xCDCBFE, 0xD9C2FF,
 		   0xECBEFF, 0xFAC2EB, 0xF7CAC3, 0xE3CDA7,
 		   0xD9DE9C, 0xC8E69E, 0xC0E6B8, 0xB5EDC7,
-		   0xB9E6EA, 0xB8B8B8, 0x000000, 0x000000}
+		   0xB9E6EA, 0xB8B8B8, 0x000000, 0x000000 }
+   },
+   { "nescap", "RGBSource's NESCAP palette",
+	   { 0x646365, 0x001580, 0x1D0090, 0x380082,
+		   0x56005D, 0x5A001A, 0x4F0900, 0x381B00,
+		   0x1E3100, 0x003D00, 0x004100, 0x003A1B,
+		   0x002F55, 0x000000, 0x000000, 0x000000,
+		   0xAFADAF, 0x164BCA, 0x472AE7, 0x6B1BDB,
+		   0x9617B0, 0x9F185B, 0x963001, 0x7B4800,
+		   0x5A6600, 0x237800, 0x017F00, 0x00783D,
+		   0x006C8C, 0x000000, 0x000000, 0x000000,
+		   0xFFFFFF, 0x60A6FF, 0x8F84FF, 0xB473FF,
+		   0xE26CFF, 0xF268C3, 0xEF7E61, 0xD89527,
+		   0xBAB307, 0x81C807, 0x57D43D, 0x47CF7E,
+		   0x4BC5CD, 0x4C4B4D, 0x000000, 0x000000,
+		   0xFFFFFF, 0xC2E0FF, 0xD5D2FF, 0xE3CBFF,
+		   0xF7C8FF, 0xFEC6EE, 0xFECEC6, 0xF6D7AE,
+		   0xE9E49F, 0xD3ED9D, 0xC0F2B2, 0xB9F1CC,
+		   0xBAEDED, 0xBAB9BB, 0x000000, 0x000000 }
    }
 };
 
@@ -621,7 +639,7 @@ void retro_set_controller_port_device(unsigned a, unsigned b)
 void retro_set_environment(retro_environment_t cb)
 {
    static const struct retro_variable vars[] = {
-      { "fceumm_palette", "Color Palette; asqrealc|loopy|quor|chris|matt|pasofami|crashman|mess|zaphod-cv|zaphod-smb|vs-drmar|vs-cv|vs-smb|nintendo-vc|yuv-v3|unsaturated-final|sony-cxa2025as-us|pal|bmf-final2|bmf-final3|nostalgia|nes-classic|raw" },
+      { "fceumm_palette", "Color Palette; asqrealc|loopy|quor|chris|matt|pasofami|crashman|mess|zaphod-cv|zaphod-smb|vs-drmar|vs-cv|vs-smb|nintendo-vc|yuv-v3|unsaturated-final|sony-cxa2025as-us|pal|bmf-final2|bmf-final3|nostalgia|nes-classic|nescap|raw" },
       { "fceumm_nospritelimit", "No Sprite Limit; disabled|enabled" },
       { "fceumm_overclocking", "Overclocking; disabled|2x" },
       { "fceumm_overscan", "Crop Overscan; enabled|disabled" },
@@ -697,7 +715,7 @@ static void retro_set_custom_palette (void)
       return;
    }
 
-   if (current_palette == 23) /* raw palette */
+   if (current_palette == 24) /* raw palette */
    {
       use_raw_palette = true;
       for (i = 0; i < 64; i++)
@@ -822,8 +840,10 @@ static void check_variables(void)
          current_palette = 21;
       else if (!strcmp(var.value, "nes-classic"))
          current_palette = 22;
-      else if (!strcmp(var.value, "raw"))
+      else if (!strcmp(var.value, "nescap"))
          current_palette = 23;
+      else if (!strcmp(var.value, "raw"))
+         current_palette = 24;
 
       if (current_palette != orig_value)
          retro_set_custom_palette();

--- a/src/drivers/libretro/libretro.c
+++ b/src/drivers/libretro/libretro.c
@@ -178,7 +178,7 @@ FILE *FCEUD_UTF8fopen(const char *n, const char *m)
 #define MAX_PATH 1024
 
 /*palette for FCEU*/
-#define MAXPAL 20
+#define MAXPAL 22
 
 struct st_palettes {
 	char name[32];
@@ -547,6 +547,42 @@ struct st_palettes palettes[] = {
 		   0xF8B0FF, 0xFEB0EC, 0xFDBDB5, 0xF9D28E,
 		   0xE8EB7C, 0xBBF382, 0x99F7A2, 0x8AF5D0,
 		   0x92F4F1, 0xBEBEBE, 0x000000, 0x000000 }
+   },
+   { "nostalgia", "FBX's Nostalgia palette",
+	   { 0x656565, 0x00127D, 0x18008E, 0x360082,
+		   0x56005D, 0x5A0018, 0x4F0500, 0x381900,
+		   0x1D3100, 0x003D00, 0x004100, 0x003B17,
+		   0x002E55, 0x000000, 0x000000, 0x000000,
+		   0xAFAFAF, 0x194EC8, 0x472FE3, 0x6B1FD7,
+		   0x931BAE, 0x9E1A5E, 0x973200, 0x7B4B00,
+		   0x5B6700, 0x267A00, 0x008200, 0x007A3E,
+		   0x006E8A, 0x000000, 0x000000, 0x000000,
+		   0xFFFFFF, 0x64A9FF, 0x8E89FF, 0xB676FF,
+		   0xE06FFF, 0xEF6CC4, 0xF0806A, 0xD8982C,
+		   0xB9B40A, 0x83CB0C, 0x5BD63F, 0x4AD17E,
+		   0x4DC7CB, 0x4C4C4C, 0x000000, 0x000000,
+		   0xFFFFFF, 0xC7E5FF, 0xD9D9FF, 0xE9D1FF,
+		   0xF9CEFF, 0xFFCCF1, 0xFFD4CB, 0xF8DFB1,
+		   0xEDEAA4, 0xD6F4A4, 0xC5F8B8, 0xBEF6D3,
+		   0xBFF1F1, 0xB9B9B9, 0x000000, 0x000000 }
+   },
+   { "nes-classic", "FBX's NES-Classic palette",
+	   { 0x606060, 0x000083, 0x1F069E, 0x380F7C,
+		   0x560C62, 0x5B0010, 0x530C00, 0x3A2308,
+		   0x20350B, 0x0C410B, 0x194516, 0x023E1E,
+		   0x023154, 0x000000, 0x000000, 0x000000,
+		   0xA9A9A9, 0x104BBF, 0x4A1EE4, 0x690AD2,
+		   0x8E12B2, 0x9E0F4C, 0x8F3204, 0x735106,
+		   0x5C6A12, 0x187D10, 0x148109, 0x117547,
+		   0x1D668F, 0x000000, 0x000000, 0x000000,
+		   0xFBFBFB, 0x6699F8, 0x8978FE, 0xB262FF,
+		   0xDE63FF, 0xEB69B3, 0xE38758, 0xC89F22,
+		   0xA7B103, 0x73C203, 0x5DD04F, 0x36C58D,
+		   0x50C5CC, 0x404040, 0x000000, 0x000000,
+		   0xFBFBFB, 0xBFD4FA, 0xCDCBFE, 0xD9C2FF,
+		   0xECBEFF, 0xFAC2EB, 0xF7CAC3, 0xE3CDA7,
+		   0xD9DE9C, 0xC8E69E, 0xC0E6B8, 0xB5EDC7,
+		   0xB9E6EA, 0xB8B8B8, 0x000000, 0x000000}
    }
 };
 
@@ -585,7 +621,7 @@ void retro_set_controller_port_device(unsigned a, unsigned b)
 void retro_set_environment(retro_environment_t cb)
 {
    static const struct retro_variable vars[] = {
-      { "fceumm_palette", "Color Palette; asqrealc|loopy|quor|chris|matt|pasofami|crashman|mess|zaphod-cv|zaphod-smb|vs-drmar|vs-cv|vs-smb|nintendo-vc|yuv-v3|unsaturated-final|sony-cxa2025as-us|pal|bmf-final2|bmf-final3|raw" },
+      { "fceumm_palette", "Color Palette; asqrealc|loopy|quor|chris|matt|pasofami|crashman|mess|zaphod-cv|zaphod-smb|vs-drmar|vs-cv|vs-smb|nintendo-vc|yuv-v3|unsaturated-final|sony-cxa2025as-us|pal|bmf-final2|bmf-final3|nostalgia|nes-classic|raw" },
       { "fceumm_nospritelimit", "No Sprite Limit; disabled|enabled" },
       { "fceumm_overclocking", "Overclocking; disabled|2x" },
       { "fceumm_overscan", "Crop Overscan; enabled|disabled" },
@@ -661,7 +697,7 @@ static void retro_set_custom_palette (void)
       return;
    }
 
-   if (current_palette == 21) /* raw palette */
+   if (current_palette == 23) /* raw palette */
    {
       use_raw_palette = true;
       for (i = 0; i < 64; i++)
@@ -782,8 +818,12 @@ static void check_variables(void)
          current_palette = 19;
       else if (!strcmp(var.value, "bmf-final3"))
          current_palette = 20;
-      else if (!strcmp(var.value, "raw"))
+      else if (!strcmp(var.value, "nostalgia"))
          current_palette = 21;
+      else if (!strcmp(var.value, "nes-classic"))
+         current_palette = 22;
+      else if (!strcmp(var.value, "raw"))
+         current_palette = 23;
 
       if (current_palette != orig_value)
          retro_set_custom_palette();

--- a/src/drivers/libretro/libretro.c
+++ b/src/drivers/libretro/libretro.c
@@ -458,23 +458,23 @@ struct st_palettes palettes[] = {
 		   0xE4E594, 0xCFEF96, 0xBDF4AB, 0xB3F3CC,
 		   0xB5EBF2, 0xB8B8B8, 0x000000, 0x000000 }
    },
-   { "unsaturated-v6", "FBX's Unsaturated-V6 palette",
-	   { 0x6B6B6B, 0x001E87, 0x1F0B96, 0x3B0C87,
-		   0x590D61, 0x5E0528, 0x551100, 0x461B00,
-		   0x303200, 0x0A4800, 0x004E00, 0x004619,
-		   0x003A58, 0x000000, 0x000000, 0x000000,
-		   0xB2B2B2, 0x1A53D1, 0x4835EE, 0x7123EC,
-		   0x9A1EB7, 0xA51E62, 0xA52D19, 0x874B00,
-		   0x676900, 0x298400, 0x038B00, 0x008240,
-		   0x007891, 0x000000, 0x000000, 0x000000,
-		   0xFFFFFF, 0x63ADFD, 0x908AFE, 0xB977FC,
-		   0xE771FE, 0xF76FC9, 0xF5836A, 0xDD9C29,
-		   0xBDB807, 0x84D107, 0x5BDC3B, 0x48D77D,
-		   0x48CCCE, 0x555555, 0x000000, 0x000000,
-		   0xFFFFFF, 0xC4E3FE, 0xD7D5FE, 0xE6CDFE,
-		   0xF9CAFE, 0xFEC9F0, 0xFED1C7, 0xF7DCAC,
-		   0xE8E89C, 0xD1F29D, 0xBFF4B1, 0xB7F5CD,
-		   0xB7F0EE, 0xBEBEBE, 0x000000, 0x000000 }
+   { "unsaturated-final", "FBX's Unsaturated-Final palette",
+	   { 0x676767, 0x001F8E, 0x23069E, 0x40008E,
+		   0x600067, 0x67001C, 0x5B1000, 0x432500,
+		   0x313400, 0x074800, 0x004F00, 0x004622,
+		   0x003A61, 0x000000, 0x000000, 0x000000,
+		   0xB3B3B3, 0x205ADF, 0x5138FB, 0x7A27EE,
+		   0xA520C2, 0xB0226B, 0xAD3702, 0x8D5600,
+		   0x6E7000, 0x2E8A00, 0x069200, 0x008A47,
+		   0x037B9B, 0x101010, 0x000000, 0x000000,
+		   0xFFFFFF, 0x62AEFF, 0x918BFF, 0xBC78FF,
+		   0xE96EFF, 0xFC6CCD, 0xFA8267, 0xE29B26,
+		   0xC0B901, 0x84D200, 0x58DE38, 0x46D97D,
+		   0x49CED2, 0x494949, 0x000000, 0x000000,
+		   0xFFFFFF, 0xC1E3FF, 0xD5D4FF, 0xE7CCFF,
+		   0xFBC9FF, 0xFFC7F0, 0xFFD0C5, 0xF8DAAA,
+		   0xEBE69A, 0xD1F19A, 0xBEF7AF, 0xB6F4CD,
+		   0xB7F0EF, 0xB2B2B2, 0x000000, 0x000000 }
    },
    { "sony-cxa2025as-us", "Sony CXA2025AS US palette",
 	   { 0x585858, 0x00238C, 0x00139B, 0x2D0585,
@@ -585,7 +585,7 @@ void retro_set_controller_port_device(unsigned a, unsigned b)
 void retro_set_environment(retro_environment_t cb)
 {
    static const struct retro_variable vars[] = {
-      { "fceumm_palette", "Color Palette; asqrealc|loopy|quor|chris|matt|pasofami|crashman|mess|zaphod-cv|zaphod-smb|vs-drmar|vs-cv|vs-smb|nintendo-vc|yuv-v3|unsaturated-v6|sony-cxa2025as-us|pal|bmf-final2|bmf-final3|raw" },
+      { "fceumm_palette", "Color Palette; asqrealc|loopy|quor|chris|matt|pasofami|crashman|mess|zaphod-cv|zaphod-smb|vs-drmar|vs-cv|vs-smb|nintendo-vc|yuv-v3|unsaturated-final|sony-cxa2025as-us|pal|bmf-final2|bmf-final3|raw" },
       { "fceumm_nospritelimit", "No Sprite Limit; disabled|enabled" },
       { "fceumm_overclocking", "Overclocking; disabled|2x" },
       { "fceumm_overscan", "Crop Overscan; enabled|disabled" },
@@ -772,7 +772,7 @@ static void check_variables(void)
          current_palette = 14;
       else if (!strcmp(var.value, "yuv-v3"))
          current_palette = 15;
-      else if (!strcmp(var.value, "unsaturated-v6"))
+      else if (!strcmp(var.value, "unsaturated-final"))
          current_palette = 16;
       else if (!strcmp(var.value, "sony-cxa2025as-us"))
          current_palette = 17;


### PR DESCRIPTION
Updated FirebrandX's palettes and added the two new ones from http://www.firebrandx.com/nespalette.html

Added RGBSource's NESCAP palette, originally posted at http://rgbsource.blogspot.com/2016/10/creating-accurate-nes-ntsc-color.html