### PR TITLE
*DO NOT MERGE* Make need fullpath false proposal

### DIFF
--- a/src/drivers/libretro/libretro.c
+++ b/src/drivers/libretro/libretro.c
@@ -696,7 +696,11 @@ void retro_set_environment(retro_environment_t cb)
 
 void retro_get_system_info(struct retro_system_info *info)
 {
+#ifdef PSP
    info->need_fullpath = true;
+#else
+   info->need_fullpath = false;
+#endif
    info->valid_extensions = "fds|nes|unf|unif";
 #ifdef GIT_VERSION
    info->library_version = "git" GIT_VERSION;

--- a/src/file.c
+++ b/src/file.c
@@ -73,6 +73,7 @@ static MEMWRAP *MakeMemWrapBuffer(void *tz, int type, uint8 *buffer, size_t bufs
    tmp->location = 0;
    tmp->size = bufsize;
    tmp->data = buffer;
+   fclose((FILE*)tz);
 
    return tmp;
 }
@@ -125,7 +126,7 @@ uint64 FCEU_fread(void *ptr, size_t element_size, size_t nmemb, FCEUFILE *fp)
 
       return (ak / element_size);
    }
-   
+
    memcpy((uint8_t*)ptr, fp->fp->data + fp->fp->location, total);
 
    fp->fp->location += total;


### PR DESCRIPTION
bug tracking done here: https://github.com/libretro/libretro-fceumm/issues/68

Im proposing to re-set this option to "false" to enable softpatching. i have done some bug tracking and somehow able fixed or find reason for issues that is not related to this core option(fds not loading when patch file is used). linked above is the bug-tracking notes:

What i am not able to test is PSP since i do not have this device and it seems that PSP has a special mention on this core, so i kept the original codes and set "#define PSP" to these.

I put in DO_NOT_MERGE for I still do not know any underlying reasons that need_fullpath has been reset to true after it was modified and set to false sometime dec 2014. I did play with these settings for the past weeks or so and i cannot seem to find any general gameplay-related performance issues, although i do not know if there other areas needs cleanup or causing memory leaks.

great thanks to RA-Team, @hunterk and @Tatsuya79 for helping me troubleshoot and test.