### PR TITLE
fix overclocking audio issues

### DIFF
--- a/src/drivers/libretro/libretro.c
+++ b/src/drivers/libretro/libretro.c
@@ -55,6 +55,7 @@ unsigned overclocked = 0;
 unsigned skip_7bit_overclocking = 1;
 unsigned normal_scanlines = 240;
 unsigned extrascanlines = 0;
+unsigned overclock_state = -1;
 
 int FCEUnetplay;
 #ifdef PSP
@@ -823,7 +824,6 @@ static const keymap bindmap[] = {
 
 static void check_variables(bool startup)
 {
-   static int overclock_state = -1;
    struct retro_variable var = {0};
    struct retro_system_av_info av_info;
    bool geometry_update = false;

--- a/src/fceu.c
+++ b/src/fceu.c
@@ -462,7 +462,7 @@ void FCEU_ResetVidSys(void)
 
 	PAL = w ? 1 : 0;
 
-   totalscanlines = normal_scanlines + (overclocked ? extrascanlines : 0);
+   totalscanlines = normal_scanlines + (overclock_state ? extrascanlines : 0);
 
 	FCEUPPU_SetVideoSystem(w);
 	SetSoundVariables();

--- a/src/fceu.h
+++ b/src/fceu.h
@@ -5,6 +5,7 @@
 
 extern int fceuindbg;
 
+extern unsigned overclock_state;
 extern unsigned overclocked;
 extern unsigned skip_7bit_overclocking;
 extern unsigned DMC_7bit;

--- a/src/ppu.c
+++ b/src/ppu.c
@@ -1216,14 +1216,28 @@ int FCEUPPU_Loop(int skip) {
 			if (DMC_7bit && skip_7bit_overclocking)
 				totalscanlines = normal_scanlines;
 			else
-				totalscanlines = normal_scanlines + (overclocked ? extrascanlines : 0);
+				totalscanlines = normal_scanlines + (overclock_state ? extrascanlines : 0);
 
 			for (scanline = 0; scanline < totalscanlines; ) {	//scanline is incremented in  DoLine.  Evil. :/
 				deempcnt[deemp]++;
 				if ((PPUViewer) && (scanline == PPUViewScanline)) UpdatePPUView(1);
 				DoLine();
+				if (scanline < normal_scanlines || scanline == totalscanlines)
+					overclocked = 0;
+				else
+				{
+					if (DMC_7bit && skip_7bit_overclocking) /* 7bit sample started after 240th line */
+						break;
+					overclocked = 1;
+				}
 			}
-
+         /* For Debugging
+          * FCEU_printf("Overclock State:%d DMC+7bit:%d Skip_7bit_OC:%d\n",
+          *      overclock_state,DMC_7bit,skip_7bit_overclocking);
+          * FCEU_printf("SL:%d N_SL:%d, T_SL:%d Overclocked(for FCEU_SoundCPUHook):%d\n\n",
+          *      scanline,normal_scanlines,totalscanlines,overclocked);
+         */
+			DMC_7bit = 0;
 			if (MMC5Hack && (ScreenON || SpriteON)) MMC5_hb(scanline);
 			for (x = 1, max = 0, maxref = 0; x < 7; x++) {
 				if (deempcnt[x] > max) {

--- a/src/ppu.c
+++ b/src/ppu.c
@@ -662,8 +662,15 @@ static void Fixit1(void) {
 
 void MMC5_hb(int);		//Ugh ugh ugh.
 static void DoLine(void) {
+   if (scanline >= 240 && scanline != totalscanlines) {
+		X6502_Run(256 + 69);
+		scanline++;
+		X6502_Run(16);
+		return;
+	}
+
 	int x;
-	uint8 *target = XBuf + (scanline << 8);
+	uint8 *target = XBuf + ((scanline < 240 ? scanline : 240) << 8);
 
 	if (MMC5Hack && (ScreenON || SpriteON)) MMC5_hb(scanline);
 
@@ -1231,11 +1238,11 @@ int FCEUPPU_Loop(int skip) {
 					overclocked = 1;
 				}
 			}
-         /* For Debugging
-          * FCEU_printf("Overclock State:%d DMC+7bit:%d Skip_7bit_OC:%d\n",
-          *      overclock_state,DMC_7bit,skip_7bit_overclocking);
-          * FCEU_printf("SL:%d N_SL:%d, T_SL:%d Overclocked(for FCEU_SoundCPUHook):%d\n\n",
-          *      scanline,normal_scanlines,totalscanlines,overclocked);
+         /* For Debugging */
+         /*  FCEU_printf("Overclock State:%d DMC+7bit:%d Skip_7bit_OC:%d\n",
+                overclock_state,DMC_7bit,skip_7bit_overclocking);
+           FCEU_printf("SL:%d N_SL:%d, T_SL:%d Overclocked(for FCEU_SoundCPUHook):%d\n\n",
+                scanline,normal_scanlines,totalscanlines,overclocked);
          */
 			DMC_7bit = 0;
 			if (MMC5Hack && (ScreenON || SpriteON)) MMC5_hb(scanline);

--- a/src/x6502.c
+++ b/src/x6502.c
@@ -606,7 +606,8 @@ void X6502_Run(int32 cycles)
 		temp = _tcount;
 		_tcount = 0;
 		if (MapIRQHook) MapIRQHook(temp);
-		FCEU_SoundCPUHook(temp);
+		if (!overclocked)
+			FCEU_SoundCPUHook(temp);
 		X.PC = pbackus;
 		_PC++;
 		switch (b1) {


### PR DESCRIPTION
related issues : #79 #81 #73 #58 

reference to commits made:
r3107 - Added Dendy mode for Windows. /* (somehow fixes buffer overflow when 
		enabling overclock and later on when dendy is added)
r3120 - Overclocking. Implemented by adding extra scanlines to PPU loop. 
		Disabled (optionally) while 7-bit samples are playing (as they can't 
		be worked around otherwise
r3224 - Overclocking cleanup
r3228 - overclocking: break ppuloop once 7bit sample starts (if their oc is disabled)
r3231 - fix dendy buffer overflow caused by cleanup