### PR TITLE
add core option dendy and region override

### DIFF
--- a/src/fceu.c
+++ b/src/fceu.c
@@ -456,15 +456,22 @@ void FCEU_ResetVidSys(void)
 	if (GameInfo->vidsys == GIV_NTSC)
 		w = 0;
 	else if (GameInfo->vidsys == GIV_PAL)
-		w = 1;
+   {
+      w = 1;
+      dendy = 0;
+   }
 	else
 		w = FSettings.PAL;
 
 	PAL = w ? 1 : 0;
 
+   if (PAL)
+      dendy = 0;
+
+   normal_scanlines = dendy ? 290 : 240;
    totalscanlines = normal_scanlines + (overclock_state ? extrascanlines : 0);
 
-	FCEUPPU_SetVideoSystem(w);
+	FCEUPPU_SetVideoSystem(w || dendy);
 	SetSoundVariables();
 }
 
@@ -502,7 +509,7 @@ void FCEUI_SetRenderedLines(int ntscf, int ntscl, int palf, int pall)
 	FSettings.UsrLastSLine[0] = ntscl;
 	FSettings.UsrFirstSLine[1] = palf;
 	FSettings.UsrLastSLine[1] = pall;
-	if (PAL)
+	if (PAL || dendy)
    {
 		FSettings.FirstSLine = FSettings.UsrFirstSLine[1];
 		FSettings.LastSLine = FSettings.UsrLastSLine[1];
@@ -546,7 +553,7 @@ void FCEUI_SetSnapName(int a)
 
 int32 FCEUI_GetDesiredFPS(void)
 {
-	if (PAL)
+	if (PAL || dendy)
 		return(838977920);	// ~50.007
 	else
 		return(1008307711);	// ~60.1

--- a/src/fceu.h
+++ b/src/fceu.h
@@ -12,6 +12,7 @@ extern unsigned DMC_7bit;
 
 extern unsigned normal_scanlines;
 extern unsigned extrascanlines;
+extern unsigned dendy;
 
 void ResetGameLoaded(void);
 

--- a/src/ppu.c
+++ b/src/ppu.c
@@ -1060,7 +1060,7 @@ static void CopySprites(uint8 *target) {
 
 void FCEUPPU_SetVideoSystem(int w) {
 	if (w) {
-		scanlines_per_frame = 312;
+		scanlines_per_frame = dendy ? 262 : 312;
 		FSettings.FirstSLine = FSettings.UsrFirstSLine[1];
 		FSettings.LastSLine = FSettings.UsrLastSLine[1];
 	} else {

--- a/src/x6502.h
+++ b/src/x6502.h
@@ -51,7 +51,7 @@ extern X6502 X;
 
 extern void FP_FASTAPASS(1) (*MapIRQHook)(int a);
 
-#define NTSC_CPU 1789772.7272727272727272
+#define NTSC_CPU (dendy ? 1773447.467 : 1789772.7272727272727272)
 #define PAL_CPU  1662607.125
 
 #define FCEU_IQEXT      0x001


### PR DESCRIPTION
https://wiki.nesdev.com/w/index.php/Clock_rate
backport from FCEUX

TODO: find a way to auto reset region to "auto" each core load.