### PR TITLE
rename fds savefile from ".fds" to ".sav"...

### DIFF
--- a/src/general.c
+++ b/src/general.c
@@ -95,7 +95,7 @@ char *FCEU_MakeFName(int type, int id1, char *cd1)
             sprintf(tmp, "%s"PSS "gameinfo"PSS "%s.pal", BaseDirectory, FileBase);
          break;
       case FCEUMKF_FDS:
-            sprintf(tmp, "%s"PSS "%s.fds", SaveDirectory, FileBase);
+            sprintf(tmp, "%s"PSS "%s.sav", SaveDirectory, FileBase);
          break;
       default:
          break;


### PR DESCRIPTION
to avoid accidental overwrite of rom if save folder is not set and defaults to rom folder for saves.
"fceumm saves fds savefile as a copy of the original rom with the save information"