### PR TITLE
Cleanup

### DIFF
--- a/src/cart.c
+++ b/src/cart.c
@@ -261,7 +261,7 @@ void FASTAPASS(2) setchr8r(int r, uint32 V) {
 	if (CHRram[r])
 		PPUCHRRAM |= (255);
 	else
-		PPUCHRRAM &= ~(255);
+		PPUCHRRAM &= 0;
 }
 
 void FASTAPASS(2) setchr1(uint32 A, uint32 V) {

--- a/src/driver.h
+++ b/src/driver.h
@@ -40,6 +40,7 @@ void FCEUD_GetPalette(uint8 i, uint8 *r, uint8 *g, uint8 *b);
 /* Displays an error.  Can block or not. */
 void FCEUD_PrintError(char *s);
 void FCEUD_Message(char *s);
+void FCEUD_DispMessage(char *m);
 
 #ifdef NETWORK
 /* Network interface */

--- a/src/ines.c
+++ b/src/ines.c
@@ -90,7 +90,7 @@ static void iNESGI(int h) {
 		break;
 	case GI_CLOSE:
 	{
-		FCEU_SaveGameSave(&iNESCart);
+		/* FCEU_SaveGameSave(&iNESCart); */
 		if (iNESCart.Close)
 			iNESCart.Close();
 		if (ROM) {
@@ -793,7 +793,7 @@ int iNESLoad(const char *name, FCEUFILE *fp) {
 	if (!iNES_Init(MapperNo))
 		FCEU_PrintError("iNES mapper #%d is not supported at all.", MapperNo);
 
-	FCEU_LoadGameSave(&iNESCart);
+	/* FCEU_LoadGameSave(&iNESCart); */
 
 	GameInterface = iNESGI;
 	FCEU_printf("\n");

--- a/src/sound.c
+++ b/src/sound.c
@@ -952,7 +952,7 @@ int FlushEmulateSound(void) {
 	}
 	inbuf = end;
 
-	FCEU_WriteWaveData(WaveFinal, end);	/* This function will just return
+	/* FCEU_WriteWaveData(WaveFinal, end);	 This function will just return
 										if sound recording is off. */
 	return(end);
 }


### PR DESCRIPTION
-Silence warnings
-commented-out **FCEU_SaveGameSave** and **FCEU_LoadGameSave** 
  since the function is not complete(missing associated entry in FCEU_MakeFName) and Libretro handles its 
 own sram/battery  Save and Load functions.
-FCEU_WriteWaveData(WaveFinal, end); - is an empty function {}