### PR TITLE
Visual studio 2017 target

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -285,6 +285,41 @@ else ifeq ($(platform), gcw0)
 	SHARED := -shared -Wl,--version-script=src/drivers/libretro/link.T -Wl,-no-undefined
 	PLATFORM_DEFINES += -ffast-math -march=mips32 -mtune=mips32r2 -mhard-float
 	EXTERNAL_ZLIB = 1
+	
+# Windows MSVC 2017x64
+else ifeq ($(platform), windows_msvc2017_x64)
+	CC  = cl.exe
+	CXX = cl.exe
+
+VSINSTALLROOT := $(shell "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.VisualStudio.Workload.NativeDesktop -property installationPath)
+VCCOMPILERTOOLSVER := $(shell cat "$(VSINSTALLROOT)\VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt" | grep -o '[0-9\.]*')
+VCCOMPILERTOOLSDIR := $(VSINSTALLROOT)\VC\Tools\MSVC\$(VCCOMPILERTOOLSVER)
+
+ifeq ($(PROCESSOR_ARCHITECTURE),AMD64)
+HOSTCPUARCHDIR := HostX64
+else
+HOSTCPUARCHDIR := HostX86
+endif
+
+VCCOMPILERTOOLSBINDIR := $(VCCOMPILERTOOLSDIR)\bin\$(HOSTCPUARCHDIR)
+
+PATH := $(shell IFS=$$'\n'; cygpath "$(VCCOMPILERTOOLSBINDIR)/x64"):$(PATH)
+PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VSINSTALLROOT)/Common7/IDE")
+INCLUDE := $(shell IFS=$$'\n'; cygpath "$(VCCOMPILERTOOLSDIR)/include")
+LIB := $(shell IFS=$$'\n'; cygpath "$(VCCOMPILERTOOLSDIR)/lib/x64")
+BIN := $(shell IFS=$$'\n'; cygpath "$(VCCOMPILERTOOLSBINDIR)")
+
+WindowsSdkDir := $(shell reg query "HKLM\SOFTWARE\WOW6432Node\Microsoft\Microsoft SDKs\Windows\v10.0" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')lib/x64
+WindowsSdkDir ?= $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')lib/x64
+
+$(info sdkdir: $(WindowsSdkDir))
+
+export INCLUDE := $(INCLUDE)
+export LIB := $(LIB);$(WindowsSdkDir)
+TARGET := $(TARGET_NAME)_libretro.dll
+PSS_STYLE :=2
+LDFLAGS += -DLL
+
 # Windows MSVC 2010 x64
 else ifeq ($(platform), windows_msvc2010_x64)
 	CC  = cl.exe

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -291,31 +291,32 @@ else ifeq ($(platform), windows_msvc2017_x64)
 	CC  = cl.exe
 	CXX = cl.exe
 
-VSINSTALLROOT := $(shell "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.VisualStudio.Workload.NativeDesktop -property installationPath)
-VCCOMPILERTOOLSVER := $(shell cat "$(VSINSTALLROOT)\VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt" | grep -o '[0-9\.]*')
-VCCOMPILERTOOLSDIR := $(VSINSTALLROOT)\VC\Tools\MSVC\$(VCCOMPILERTOOLSVER)
+VsInstallRoot := $(shell "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.VisualStudio.Workload.NativeDesktop -property installationPath)
+VcCompilerToolsVer := $(shell cat "$(VsInstallRoot)\VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt" | grep -o '[0-9\.]*')
+VcCompilerToolsDir := $(VsInstallRoot)\VC\Tools\MSVC\$(VcCompilerToolsVer)
 
 ifeq ($(PROCESSOR_ARCHITECTURE),AMD64)
-HOSTCPUARCHDIR := HostX64
+HostCPUArchDir := HostX64
+WindowsSDKRegKey := HKLM\SOFTWARE\WOW6432Node\Microsoft\Microsoft SDKs\Windows\v10.0
 else
-HOSTCPUARCHDIR := HostX86
+HostCPUArchDir := HostX86
+WindowsSDKRegKey := HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0
 endif
 
-VCCOMPILERTOOLSBINDIR := $(VCCOMPILERTOOLSDIR)\bin\$(HOSTCPUARCHDIR)
+WindowsSDKRootDir := $(shell reg query "$(WindowsSDKRegKey)" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')
+WindowsSDKVer = $(shell reg query "$(WindowsSDKRegKey)" -v "ProductVersion" | grep -o '10\.[0-9]\.[0-9]*')
+WindowsSDKUCRTIncludeDir := $(shell cygpath "$(WindowsSDKRootDir)\Include\$(WindowsSDKVer)\ucrt")
+WindowsSDKUCRTLibDir := $(shell cygpath "$(WindowsSDKRootDir)\Lib\$(WindowsSDKVer)\ucrt\x64")
 
-PATH := $(shell IFS=$$'\n'; cygpath "$(VCCOMPILERTOOLSBINDIR)/x64"):$(PATH)
-PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VSINSTALLROOT)/Common7/IDE")
-INCLUDE := $(shell IFS=$$'\n'; cygpath "$(VCCOMPILERTOOLSDIR)/include")
-LIB := $(shell IFS=$$'\n'; cygpath "$(VCCOMPILERTOOLSDIR)/lib/x64")
-BIN := $(shell IFS=$$'\n'; cygpath "$(VCCOMPILERTOOLSBINDIR)")
+VCCompilerToolsBinDir := $(VcCompilerToolsDir)\bin\$(HostCPUArchDir)
 
-WindowsSdkDir := $(shell reg query "HKLM\SOFTWARE\WOW6432Node\Microsoft\Microsoft SDKs\Windows\v10.0" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')lib/x64
-WindowsSdkDir ?= $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')lib/x64
+PATH := $(shell IFS=$$'\n'; cygpath "$(VCCompilerToolsBinDir)/x64"):$(PATH)
+PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VsInstallRoot)/Common7/IDE")
+INCLUDE := $(shell IFS=$$'\n'; cygpath "$(VcCompilerToolsDir)/include")
+LIB := $(shell IFS=$$'\n'; cygpath "$(VcCompilerToolsDir)/lib/x64")
 
-$(info sdkdir: $(WindowsSdkDir))
-
-export INCLUDE := $(INCLUDE)
-export LIB := $(LIB);$(WindowsSdkDir)
+export INCLUDE := $(INCLUDE);$(WindowsSDKUCRTIncludeDir)
+export LIB := $(LIB);$(WindowsSDKUCRTLibDir)
 TARGET := $(TARGET_NAME)_libretro.dll
 PSS_STYLE :=2
 LDFLAGS += -DLL

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -291,35 +291,35 @@ else ifeq ($(platform), windows_msvc2017_x64)
 	CC  = cl.exe
 	CXX = cl.exe
 
-VsInstallRoot := $(shell "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.VisualStudio.Workload.NativeDesktop -property installationPath)
-VcCompilerToolsVer := $(shell cat "$(VsInstallRoot)\VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt" | grep -o '[0-9\.]*')
-VcCompilerToolsDir := $(VsInstallRoot)\VC\Tools\MSVC\$(VcCompilerToolsVer)
+	VsInstallRoot := $(shell "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.VisualStudio.Workload.NativeDesktop -property installationPath)
+	VcCompilerToolsVer := $(shell cat "$(VsInstallRoot)\VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt" | grep -o '[0-9\.]*')
+	VcCompilerToolsDir := $(VsInstallRoot)\VC\Tools\MSVC\$(VcCompilerToolsVer)
 
-ifeq ($(PROCESSOR_ARCHITECTURE),AMD64)
-HostCPUArchDir := HostX64
-WindowsSDKRegKey := HKLM\SOFTWARE\WOW6432Node\Microsoft\Microsoft SDKs\Windows\v10.0
-else
-HostCPUArchDir := HostX86
-WindowsSDKRegKey := HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0
-endif
+	ifeq ($(PROCESSOR_ARCHITECTURE),AMD64)
+	HostCPUArchDir := HostX64
+	WindowsSDKRegKey := HKLM\SOFTWARE\WOW6432Node\Microsoft\Microsoft SDKs\Windows\v10.0
+	else
+	HostCPUArchDir := HostX86
+	WindowsSDKRegKey := HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0
+	endif
 
-WindowsSDKRootDir := $(shell reg query "$(WindowsSDKRegKey)" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')
-WindowsSDKVer = $(shell reg query "$(WindowsSDKRegKey)" -v "ProductVersion" | grep -o '10\.[0-9]\.[0-9]*')
-WindowsSDKUCRTIncludeDir := $(shell cygpath "$(WindowsSDKRootDir)\Include\$(WindowsSDKVer)\ucrt")
-WindowsSDKUCRTLibDir := $(shell cygpath "$(WindowsSDKRootDir)\Lib\$(WindowsSDKVer)\ucrt\x64")
+	WindowsSDKRootDir := $(shell reg query "$(WindowsSDKRegKey)" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')
+	WindowsSDKVer = $(shell reg query "$(WindowsSDKRegKey)" -v "ProductVersion" | grep -o '10\.[0-9]\.[0-9]*')
+	WindowsSDKUCRTIncludeDir := $(shell cygpath "$(WindowsSDKRootDir)\Include\$(WindowsSDKVer)\ucrt")
+	WindowsSDKUCRTLibDir := $(shell cygpath "$(WindowsSDKRootDir)\Lib\$(WindowsSDKVer)\ucrt\x64")
 
-VCCompilerToolsBinDir := $(VcCompilerToolsDir)\bin\$(HostCPUArchDir)
+	VCCompilerToolsBinDir := $(VcCompilerToolsDir)\bin\$(HostCPUArchDir)
 
-PATH := $(shell IFS=$$'\n'; cygpath "$(VCCompilerToolsBinDir)/x64"):$(PATH)
-PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VsInstallRoot)/Common7/IDE")
-INCLUDE := $(shell IFS=$$'\n'; cygpath "$(VcCompilerToolsDir)/include")
-LIB := $(shell IFS=$$'\n'; cygpath "$(VcCompilerToolsDir)/lib/x64")
+	PATH := $(shell IFS=$$'\n'; cygpath "$(VCCompilerToolsBinDir)/x64"):$(PATH)
+	PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VsInstallRoot)/Common7/IDE")
+	INCLUDE := $(shell IFS=$$'\n'; cygpath "$(VcCompilerToolsDir)/include")
+	LIB := $(shell IFS=$$'\n'; cygpath "$(VcCompilerToolsDir)/lib/x64")
 
-export INCLUDE := $(INCLUDE);$(WindowsSDKUCRTIncludeDir)
-export LIB := $(LIB);$(WindowsSDKUCRTLibDir)
-TARGET := $(TARGET_NAME)_libretro.dll
-PSS_STYLE :=2
-LDFLAGS += -DLL
+	export INCLUDE := $(INCLUDE);$(WindowsSDKUCRTIncludeDir)
+	export LIB := $(LIB);$(WindowsSDKUCRTLibDir)
+	TARGET := $(TARGET_NAME)_libretro.dll
+	PSS_STYLE :=2
+	LDFLAGS += -DLL
 
 # Windows MSVC 2010 x64
 else ifeq ($(platform), windows_msvc2010_x64)


### PR DESCRIPTION
@twinaphex @hunterk

Opening this to make it easier to discuss.

Sadly it does not work yet and I haven't been able to make progress in the last few days.
If at all possible, I'd like to ask for help.

Visual Studio 2017 has completely changed the organization of build tools on disk, so build scripts for previous versions cannot be directly translated.

What I have done so far is:

- Figure out how to detect the path of `cl.exe` and other build tools, add them to the `PATH` env variable
- Figure out how to detect the path of include and lib files in VS's build tools folder structure
- Figure out how to detect the path of the Windows SDK. Of note, the C runtime is located there now ([UCRT](https://blogs.msdn.microsoft.com/vcblog/2015/03/03/introducing-the-universal-crt/), to be used for both Desktop and UWP builds)

When I attempt to build `cl.exe` seems unable to find standard C headers, which are now part of the UCRT, and I cannot understand what I am doing wrong.

```
export INCLUDE := $(INCLUDE);$(WindowsSDKUCRTIncludeDir) 
```

Should be the way to pass include directories and `WindowsSDKUCRTIncludeDir` is where the header files in question are located.

Can anyone with more experience than me with makefiles point out what I am doing wrong?