### PR TITLE
WinRT build file

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -333,12 +333,6 @@ else ifneq (,$(findstring windows_msvc2017,$(platform)))
 	VcCompilerToolsVer := $(shell cat "$(VsInstallRoot)/VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt" | grep -o '[0-9\.]*')
 	VcCompilerToolsDir := $(VsInstallRoot)/VC/Tools/MSVC/$(VcCompilerToolsVer)
 
-	ifeq ($(PROCESSOR_ARCHITECTURE),AMD64)
-		HostCPUArchDir := HostX64
-	else
-		HostCPUArchDir := HostX86
-	endif
-
 	TargetArchMoniker = $(subst windows_msvc2017_,,$(platform))
 
 	WindowsSDKUCRTIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\ucrt")
@@ -346,7 +340,8 @@ else ifneq (,$(findstring windows_msvc2017,$(platform)))
 	WindowsSDKUCRTLibDir := $(shell cygpath -w "$(WindowsSdkDir)\Lib\$(WindowsSDKVersion)\ucrt\$(TargetArchMoniker)")
 	WindowsSDKUMLibDir := $(shell cygpath -w "$(WindowsSdkDir)\Lib\$(WindowsSDKVersion)\um\$(TargetArchMoniker)")
 
-	VCCompilerToolsBinDir := $(VcCompilerToolsDir)\bin\$(HostCPUArchDir)
+	#Turns out only the x86 cl.exe can compile for everything, the x64 one only compiles x64
+	VCCompilerToolsBinDir := $(VcCompilerToolsDir)\bin\HostX86
 
 	PATH := $(shell IFS=$$'\n'; cygpath "$(VCCompilerToolsBinDir)/$(TargetArchMoniker)"):$(PATH)
 	PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VsInstallRoot)/Common7/IDE")

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -342,17 +342,18 @@ else ifneq (,$(findstring windows_msvc2017,$(platform)))
 	TargetArchMoniker = $(subst windows_msvc2017_,,$(platform))
 
 	WindowsSDKUCRTIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\ucrt")
+	WindowsSDKUMIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\um")
 	WindowsSDKUCRTLibDir := $(shell cygpath -w "$(WindowsSdkDir)\Lib\$(WindowsSDKVersion)\ucrt\$(TargetArchMoniker)")
 	WindowsSDKUMLibDir := $(shell cygpath -w "$(WindowsSdkDir)\Lib\$(WindowsSDKVersion)\um\$(TargetArchMoniker)")
 
 	VCCompilerToolsBinDir := $(VcCompilerToolsDir)\bin\$(HostCPUArchDir)
-	
+
 	PATH := $(shell IFS=$$'\n'; cygpath "$(VCCompilerToolsBinDir)/$(TargetArchMoniker)"):$(PATH)
 	PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VsInstallRoot)/Common7/IDE")
 	INCLUDE := $(shell IFS=$$'\n'; cygpath -w "$(VcCompilerToolsDir)/include")
 	LIB := $(shell IFS=$$'\n'; cygpath -w "$(VcCompilerToolsDir)/lib/$(TargetArchMoniker)")
 
-	export INCLUDE := $(INCLUDE);$(WindowsSDKUCRTIncludeDir)
+	export INCLUDE := $(INCLUDE);$(WindowsSDKUCRTIncludeDir);$(WindowsSDKUMIncludeDir)
 	export LIB := $(LIB);$(WindowsSDKUCRTLibDir);$(WindowsSDKUMLibDir)
 	TARGET := $(TARGET_NAME)_libretro.dll
 	PSS_STYLE :=2

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -299,8 +299,10 @@ else ifneq (,$(findstring windows_msvc2017,$(platform)))
 	PlatformSuffix = $(subst windows_msvc2017_,,$(platform))
 	ifneq (,$(findstring desktop,$(PlatformSuffix)))
 		WinPartition = desktop
+		CFLAGS += -DWINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP
 	else ifneq (,$(findstring uwp,$(PlatformSuffix)))
 		WinPartition = uwp
+		CFLAGS += -DWINAPI_FAMILY=WINAPI_FAMILY_APP
 	endif
 
 	TargetArchMoniker = $(subst $(WinPartition)_,,$(PlatformSuffix))
@@ -343,6 +345,7 @@ else ifneq (,$(findstring windows_msvc2017,$(platform)))
 	VcCompilerToolsVer := $(shell cat "$(VsInstallRoot)/VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt" | grep -o '[0-9\.]*')
 	VcCompilerToolsDir := $(VsInstallRoot)/VC/Tools/MSVC/$(VcCompilerToolsVer)
 
+	WindowsSDKSharedIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\shared")
 	WindowsSDKUCRTIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\ucrt")
 	WindowsSDKUMIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\um")
 	WindowsSDKUCRTLibDir := $(shell cygpath -w "$(WindowsSdkDir)\Lib\$(WindowsSDKVersion)\ucrt\$(TargetArchMoniker)")
@@ -356,7 +359,7 @@ else ifneq (,$(findstring windows_msvc2017,$(platform)))
 	INCLUDE := $(shell IFS=$$'\n'; cygpath -w "$(VcCompilerToolsDir)/include")
 	LIB := $(shell IFS=$$'\n'; cygpath -w "$(VcCompilerToolsDir)/lib/$(TargetArchMoniker)")
 
-	export INCLUDE := $(INCLUDE);$(WindowsSDKUCRTIncludeDir);$(WindowsSDKUMIncludeDir)
+	export INCLUDE := $(INCLUDE);$(WindowsSDKSharedIncludeDir);$(WindowsSDKUCRTIncludeDir);$(WindowsSDKUMIncludeDir)
 	export LIB := $(LIB);$(WindowsSDKUCRTLibDir);$(WindowsSDKUMLibDir)
 	TARGET := $(TARGET_NAME)_libretro.dll
 	PSS_STYLE :=2

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -293,8 +293,8 @@ else ifeq ($(platform), gcw0)
 	PLATFORM_DEFINES += -ffast-math -march=mips32 -mtune=mips32r2 -mhard-float
 	EXTERNAL_ZLIB = 1
 	
-# Windows MSVC 2017 x64
-else ifeq ($(platform), windows_msvc2017_x64)
+# Windows MSVC 2017 all architectures
+else ifneq (,$(findstring windows_msvc2017,$(platform)))
 	CC  = cl.exe
 	CXX = cl.exe
 
@@ -339,16 +339,18 @@ else ifeq ($(platform), windows_msvc2017_x64)
 		HostCPUArchDir := HostX86
 	endif
 
+	TargetArchMoniker = $(subst windows_msvc2017_,,$(platform))
+
 	WindowsSDKUCRTIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\ucrt")
-	WindowsSDKUCRTLibDir := $(shell cygpath -w "$(WindowsSdkDir)\Lib\$(WindowsSDKVersion)\ucrt\x64")
-	WindowsSDKUMLibDir := $(shell cygpath -w "$(WindowsSdkDir)\Lib\$(WindowsSDKVersion)\um\x64")
+	WindowsSDKUCRTLibDir := $(shell cygpath -w "$(WindowsSdkDir)\Lib\$(WindowsSDKVersion)\ucrt\$(TargetArchMoniker)")
+	WindowsSDKUMLibDir := $(shell cygpath -w "$(WindowsSdkDir)\Lib\$(WindowsSDKVersion)\um\$(TargetArchMoniker)")
 
 	VCCompilerToolsBinDir := $(VcCompilerToolsDir)\bin\$(HostCPUArchDir)
-
-	PATH := $(shell IFS=$$'\n'; cygpath "$(VCCompilerToolsBinDir)/x64"):$(PATH)
+	
+	PATH := $(shell IFS=$$'\n'; cygpath "$(VCCompilerToolsBinDir)/$(TargetArchMoniker)"):$(PATH)
 	PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VsInstallRoot)/Common7/IDE")
 	INCLUDE := $(shell IFS=$$'\n'; cygpath -w "$(VcCompilerToolsDir)/include")
-	LIB := $(shell IFS=$$'\n'; cygpath -w "$(VcCompilerToolsDir)/lib/x64")
+	LIB := $(shell IFS=$$'\n'; cygpath -w "$(VcCompilerToolsDir)/lib/$(TargetArchMoniker)")
 
 	export INCLUDE := $(INCLUDE);$(WindowsSDKUCRTIncludeDir)
 	export LIB := $(LIB);$(WindowsSDKUCRTLibDir);$(WindowsSDKUMLibDir)

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -295,6 +295,16 @@ else ifeq ($(platform), gcw0)
 	
 # Windows MSVC 2017 all architectures
 else ifneq (,$(findstring windows_msvc2017,$(platform)))
+
+	PlatformSuffix = $(subst windows_msvc2017_,,$(platform))
+	ifneq (,$(findstring desktop,$(PlatformSuffix)))
+		WinPartition = desktop
+	else ifneq (,$(findstring uwp,$(PlatformSuffix)))
+		WinPartition = uwp
+	endif
+
+	TargetArchMoniker = $(subst $(WinPartition)_,,$(PlatformSuffix))
+
 	CC  = cl.exe
 	CXX = cl.exe
 
@@ -332,8 +342,6 @@ else ifneq (,$(findstring windows_msvc2017,$(platform)))
 
 	VcCompilerToolsVer := $(shell cat "$(VsInstallRoot)/VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt" | grep -o '[0-9\.]*')
 	VcCompilerToolsDir := $(VsInstallRoot)/VC/Tools/MSVC/$(VcCompilerToolsVer)
-
-	TargetArchMoniker = $(subst windows_msvc2017_,,$(platform))
 
 	WindowsSDKUCRTIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\ucrt")
 	WindowsSDKUMIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\um")


### PR DESCRIPTION
@twinaphex 

I modified the makefile to allow for compilation on multiple architectures (x86, x64, arm) for desktop as well as UWP.

Supported platforms are now:
- windows_msvc2017_desktop_x86
- windows_msvc2017_desktop_x64
- windows_msvc2017_uwp_x86
- windows_msvc2017_uwp_x64
- windows_msvc2017_uwp_arm

This is still incomplete: in particular, appropriate command line parameters need to be passed to the linker, which is something I would like to ask for help with.

I have also managed to dig into the differences between desktop and  UWP projects in Visual Studio, and dumped the command line parameters sent to the compiler and linker in both cases.

# Desktop DLL
## Compiler parameters
```
/Yu"stdafx.h" /GS /GL /analyze- /W3 /Gy /Zc:wchar_t /Zi /Gm- /O2 /sdl /Fd"Release\vc141.pdb" /Zc:inline /fp:precise /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /D "_UNICODE" /D "UNICODE" /errorReport:prompt /WX- /Zc:forScope /Gd /Oy- /Oi /MD /Fa"Release\" /EHsc /nologo /Fo"Release\" /Fp"Release\DesktopDLL.pch" /diagnostics:classic 
```

## Linker parameters
```
/OUT:"C:\Users\Alberto\Documents\Visual Studio 2017\Projects\Test\Release\DesktopDLL.exe" /MANIFEST /LTCG:incremental /NXCOMPAT /PDB:"C:\Users\Alberto\Documents\Visual Studio 2017\Projects\Test\Release\DesktopDLL.pdb" /DYNAMICBASE "kernel32.lib" "user32.lib" "gdi32.lib" "winspool.lib" "comdlg32.lib" "advapi32.lib" "shell32.lib" "ole32.lib" "oleaut32.lib" "uuid.lib" "odbc32.lib" "odbccp32.lib" /DEBUG /MACHINE:X86 /OPT:REF /SAFESEH /INCREMENTAL:NO /PGD:"C:\Users\Alberto\Documents\Visual Studio 2017\Projects\Test\Release\DesktopDLL.pgd" /SUBSYSTEM:CONSOLE /MANIFESTUAC:"level='asInvoker' uiAccess='false'" /ManifestFile:"Release\DesktopDLL.exe.intermediate.manifest" /OPT:ICF /ERRORREPORT:PROMPT /NOLOGO /TLBID:1 
```

# UWP DLL
## Compiler parameters
```
/Yu"pch.h" /MP /GS /GL /analyze- /W3 /Gy /Zc:wchar_t /I"C:\Users\Alberto\Documents\Visual Studio 2017\Projects\Test\UWPDLL\" /I"Generated Files\" /I"Release\" /ZW:nostdlib /Zi /Gm- /O2 /sdl /Fd"Release\vc141.pdb" /Zc:inline /fp:precise /D "_WINDLL" /D "_UNICODE" /D "UNICODE" /D "WINAPI_FAMILY=WINAPI_FAMILY_APP" /D "__WRL_NO_DEFAULT_LIB__" /errorReport:prompt /WX- /Zc:forScope /Gd /Oy- /FU"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.11.25503\lib\x86\store\references\platform.winmd" /Oi /MD /Fa"Release\" /EHsc /nologo /Fo"Release\" /Fp"Release\UWPDLL.pch" /diagnostics:classic 
```

## Linker parameters
```
/OUT:"C:\Users\Alberto\Documents\Visual Studio 2017\Projects\Test\Release\UWPDLL\UWPDLL.dll" /MANIFEST:NO /LTCG:incremental /NXCOMPAT /PDB:"C:\Users\Alberto\Documents\Visual Studio 2017\Projects\Test\Release\UWPDLL\UWPDLL.pdb" /DYNAMICBASE "WindowsApp.lib" /IMPLIB:"C:\Users\Alberto\Documents\Visual Studio 2017\Projects\Test\Release\UWPDLL\UWPDLL.lib" /DEBUG:FULL /DLL /MACHINE:X86 /WINMD:NO /APPCONTAINER /OPT:REF /SAFESEH /PGD:"C:\Users\Alberto\Documents\Visual Studio 2017\Projects\Test\Release\UWPDLL\UWPDLL.pgd" /WINMDFILE:"C:\Users\Alberto\Documents\Visual Studio 2017\Projects\Test\Release\UWPDLL\UWPDLL.winmd" /SUBSYSTEM:CONSOLE /MANIFESTUAC:NO /ManifestFile:"Release\UWPDLL.dll.intermediate.manifest" /OPT:ICF /ERRORREPORT:PROMPT /NOLOGO /TLBID:1 
```

# Differences found so far
## Preprocessor defines
UWP defines the following:
- WINDLL
- _UNICODE
- UNICODE 
- WINAPI_FAMILY=WINAPI_FAMILY_APP
- __WRL_NO_DEFAULT_LIB__

## Linker parameters
Assembly is linked against different static libs (stubs for system DLLs):
UWP: `"WindowsApp.lib"`
Desktop: `kernel32.lib" "user32.lib" "gdi32.lib" "winspool.lib" "comdlg32.lib" "advapi32.lib" "shell32.lib" "ole32.lib" "oleaut32.lib" "uuid.lib" "odbc32.lib" "odbccp32.lib`

Also UWP passes the following parameters to the linker
```
/MANIFEST:NO /LTCG /NXCOMPAT /DYNAMICBASE /APPCONTAINER /OPT:REF /SUBSYSTEM:CONSOLE /MANIFESTUAC:NO /OPT:ICF /ERRORREPORT:PROMPT /NOLOGO /TLBID:1
```