### PR TITLE
[rt-01.c] silence warning [-Wimplicit-function-declaration]

### DIFF
--- a/src/boards/rt-01.c
+++ b/src/boards/rt-01.c
@@ -24,6 +24,7 @@
  * 
  */
 
+#include <stdlib.h>
 #include "mapinc.h"
 
 static DECLFR(UNLRT01Read) {


### PR DESCRIPTION
Silence this warning, and possible android buildfix:
src/boards/rt-01.c: In function ‘UNLRT01Read’:
src/boards/rt-01.c:36:18: warning: implicit declaration of function ‘rand’ [-Wimplicit-function-declaration]
   return 0xF2 | (rand() & 0x0D);