### PR TITLE
backport overclocking - allow to choose between vblank and postrender scanlines

### DIFF
--- a/src/drivers/libretro/libretro.c
+++ b/src/drivers/libretro/libretro.c
@@ -56,6 +56,7 @@ unsigned overclocked = 0;
 unsigned skip_7bit_overclocking = 1;
 unsigned normal_scanlines = 240;
 unsigned extrascanlines = 0;
+unsigned vblankscanlines = 0;
 unsigned overclock_state = -1;
 unsigned dendy = 0;
 
@@ -693,7 +694,7 @@ void retro_set_environment(retro_environment_t cb)
    static const struct retro_variable vars[] = {
       { "fceumm_palette", "Color Palette; asqrealc|loopy|quor|chris|matt|pasofami|crashman|mess|zaphod-cv|zaphod-smb|vs-drmar|vs-cv|vs-smb|nintendo-vc|yuv-v3|unsaturated-final|sony-cxa2025as-us|pal|bmf-final2|bmf-final3|composite-direct-fbx|pvm-style-d93-fbx|ntsc-hardware-fbx|nes-classic-fbx-fs|nescap|raw" },
       { "fceumm_nospritelimit", "No Sprite Limit; disabled|enabled" },
-      { "fceumm_overclocking", "Overclocking; disabled|2x" },
+      { "fceumm_overclocking", "Overclocking; disabled|2x-Postrender|2x-VBlank" },
       { "fceumm_overscan", "Crop Overscan; enabled|disabled" },
       { "fceumm_turbo_enable", "Turbo Enable; None|Player 1|Player 2|Both" },
       { "fceumm_turbo_delay", "Turbo Delay (in frames); 3|5|10|15|30|60|1|2" },
@@ -968,15 +969,27 @@ static void check_variables(bool startup)
          overclocked            = 0;
          skip_7bit_overclocking = 1;
          extrascanlines         = 0;
+         vblankscanlines        = 0;
          overclock_state        = 0;
          do_reinit              = true;
       }
-      else if (!strcmp(var.value, "2x")
+      else if (!strcmp(var.value, "2x-Postrender")
             && overclock_state != 1)
       {
          overclocked            = 1;
          skip_7bit_overclocking = 1;
          extrascanlines         = 266;
+         vblankscanlines        = 0;
+         overclock_state        = 1;
+         do_reinit              = true;
+      }
+      else if (!strcmp(var.value, "2x-VBlank")
+            && overclock_state != 1)
+      {
+         overclocked            = 1;
+         skip_7bit_overclocking = 1;
+         extrascanlines         = 0;
+         vblankscanlines        = 266;
          overclock_state        = 1;
          do_reinit              = true;
       }

--- a/src/drivers/libretro/libretro.c
+++ b/src/drivers/libretro/libretro.c
@@ -973,8 +973,7 @@ static void check_variables(bool startup)
          overclock_state        = 0;
          do_reinit              = true;
       }
-      else if (!strcmp(var.value, "2x-Postrender")
-            && overclock_state != 1)
+      else if (!strcmp(var.value, "2x-Postrender"))
       {
          overclocked            = 1;
          skip_7bit_overclocking = 1;
@@ -983,8 +982,7 @@ static void check_variables(bool startup)
          overclock_state        = 1;
          do_reinit              = true;
       }
-      else if (!strcmp(var.value, "2x-VBlank")
-            && overclock_state != 1)
+      else if (!strcmp(var.value, "2x-VBlank"))
       {
          overclocked            = 1;
          skip_7bit_overclocking = 1;

--- a/src/fceu.c
+++ b/src/fceu.c
@@ -365,6 +365,7 @@ void FCEUI_Emulate(uint8 **pXBuf, int32 **SoundBuf, int32 *SoundBufSize, int ski
 	timestampbase += timestamp;
 
 	timestamp = 0;
+	sound_timestamp = 0;
 
 	*pXBuf = skip ? 0 : XBuf;
 	*SoundBuf = WaveFinal;

--- a/src/fceu.h
+++ b/src/fceu.h
@@ -12,6 +12,7 @@ extern unsigned DMC_7bit;
 
 extern unsigned normal_scanlines;
 extern unsigned extrascanlines;
+extern unsigned vblankscanlines;
 extern unsigned dendy;
 
 void ResetGameLoaded(void);

--- a/src/ppu.c
+++ b/src/ppu.c
@@ -351,15 +351,6 @@ static DECLFW(B4014) {
 
 	for (x = 0; x < 256; x++)
 		X6502_DMW(0x2004, X6502_DMR(t + x));
-#define ADDCYC(x) \
-	{	  \
-		int __x = x;	   \
-		X.tcount += __x;	\
-		X.count -= __x * 48;  \
-		timestamp += __x;  \
-	}
-	ADDCYC(1);
-#undef ADDCYC
 }
 
 #define PAL(c)  ((c) + cc)

--- a/src/ppu.c
+++ b/src/ppu.c
@@ -1153,6 +1153,12 @@ int FCEUPPU_Loop(int skip) {
 				TriggerNMI();
 		}
 		X6502_Run((scanlines_per_frame - 242) * (256 + 85) - 12);
+		if (vblankscanlines)
+		{
+			overclocked = 1;
+			X6502_Run(vblankscanlines * (256 + 85) - 12);
+			overclocked = 0;
+		}
 		PPU_status &= 0x1f;
 		X6502_Run(256);
 
@@ -1237,6 +1243,7 @@ int FCEUPPU_Loop(int skip) {
                 overclock_state,DMC_7bit,skip_7bit_overclocking);
            FCEU_printf("SL:%d N_SL:%d, T_SL:%d Overclocked(for FCEU_SoundCPUHook):%d\n\n",
                 scanline,normal_scanlines,totalscanlines,overclocked);
+           FCEU_printf("extrascanlines:%d vblankscanlines:%d\n",extrascanlines,vblankscanlines);
          */
 			DMC_7bit = 0;
 			if (MMC5Hack && (ScreenON || SpriteON)) MMC5_hb(scanline);

--- a/src/sound.c
+++ b/src/sound.c
@@ -895,7 +895,7 @@ int FlushEmulateSound(void) {
 	int x;
 	int32 end, left;
 
-	if (!timestamp) return(0);
+	if (!sound_timestamp) return(0);
 
 	if (!FSettings.SndRate) {
 		left = 0;
@@ -914,7 +914,7 @@ int FlushEmulateSound(void) {
 
 		if (GameExpSound.HiFill) GameExpSound.HiFill();
 
-		for (x = timestamp; x; x--) {
+		for (x = sound_timestamp; x; x--) {
 			uint32 b = *tmpo;
 			*tmpo = (b & 65535) + wlookup2[(b >> 16) & 255] + wlookup1[b >> 24];
 			tmpo++;

--- a/src/sound.h
+++ b/src/sound.h
@@ -52,7 +52,7 @@ extern int32 WaveHi[];
 extern uint32 soundtsinc;
 
 extern uint32 soundtsoffs;
-#define SOUNDTS (timestamp + soundtsoffs)
+#define SOUNDTS (sound_timestamp + soundtsoffs)
 
 void SetNESSoundMap(void);
 void FrameSoundUpdate(void);

--- a/src/x6502.c
+++ b/src/x6502.c
@@ -33,6 +33,7 @@ void (*X6502_Run)(int32 cycles);
 #endif
 
 uint32 timestamp;
+uint32 sound_timestamp;
 void FP_FASTAPASS(1) (*MapIRQHook)(int a);
 
 #define _PC        X.PC
@@ -52,7 +53,8 @@ void FP_FASTAPASS(1) (*MapIRQHook)(int a);
 	int __x = x;									\
 	_tcount += __x;									\
 	_count -= __x * 48;								\
-   if (scanline < normal_scanlines || scanline == totalscanlines) timestamp+= __x; \
+	timestamp += __x;  \
+	if (!overclocked) sound_timestamp +=  __x; \
 }
 
 static INLINE uint8 RdMemNorm(uint32 A) {
@@ -413,7 +415,7 @@ void X6502_Init(void) {
 void X6502_Power(void) {
 	_count = _tcount = _IRQlow = _PC = _A = _X = _Y = _P = _PI = _DB = _jammed = 0;
 	_S = 0xFD;
-	timestamp = 0;
+	timestamp = sound_timestamp = 0;
 	X6502_Reset();
 }
 

--- a/src/x6502.h
+++ b/src/x6502.h
@@ -38,6 +38,7 @@ void X6502_Run(int32 cycles);
 #endif
 
 extern uint32 timestamp;
+extern uint32 sound_timestamp;
 extern X6502 X;
 
 #define N_FLAG  0x80


### PR DESCRIPTION
-removes duplicate defines ADDCYC(x) which is declared in x6502.c
-add 2x overclocking using vblank scanlines method which is sometimes performs better than postrender (notable game Contra Force)
-allow to switch between both overclock methods on-the-fly without having to choose "disabled" 1st, going back to game and then changing to next overclock method.