### PR TITLE
Revamp Overscan Core Option

### DIFF
--- a/src/drivers/libretro/libretro.c
+++ b/src/drivers/libretro/libretro.c
@@ -39,7 +39,12 @@ static retro_input_poll_t poll_cb = NULL;
 static retro_input_state_t input_cb = NULL;
 static retro_audio_sample_batch_t audio_batch_cb = NULL;
 static retro_environment_t environ_cb = NULL;
+#ifdef PSP
 static bool use_overscan;
+#else
+static bool overscan_h;
+static bool overscan_v;
+#endif
 static bool use_raw_palette;
 static bool use_par;
 int turbo_enabler;
@@ -145,7 +150,6 @@ void FCEUD_SetPalette(unsigned char index, unsigned char r, unsigned char g, uns
 void FCEUD_GetPalette(unsigned char i, unsigned char *r, unsigned char *g, unsigned char *b)
 {
 }
-
 
 bool FCEUD_ShouldDrawInputAids (void)
 {
@@ -730,7 +734,12 @@ void retro_set_environment(retro_environment_t cb)
       { "fceumm_palette", "Color Palette; default|asqrealc|loopy|quor|chris|matt|pasofami|crashman|mess|zaphod-cv|zaphod-smb|vs-drmar|vs-cv|vs-smb|nintendo-vc|yuv-v3|unsaturated-final|sony-cxa2025as-us|pal|bmf-final2|bmf-final3|smooth-fbx|composite-direct-fbx|pvm-style-d93-fbx|ntsc-hardware-fbx|nes-classic-fbx-fs|nescap|wavebeam|raw" },
       { "fceumm_nospritelimit", "No Sprite Limit; disabled|enabled" },
       { "fceumm_overclocking", "Overclocking; disabled|2x-Postrender|2x-VBlank" },
+#ifdef PSP
       { "fceumm_overscan", "Crop Overscan; enabled|disabled" },
+#else
+      { "fceumm_overscan_h", "Crop Overscan (Horizontal); disabled|enabled" },
+      { "fceumm_overscan_v", "Crop Overscan (Vertical); enabled|disabled" },
+#endif
       { "fceumm_turbo_enable", "Turbo Enable; None|Player 1|Player 2|Both" },
       { "fceumm_turbo_delay", "Turbo Delay (in frames); 3|5|10|15|30|60|1|2" },
       { "fceumm_aspect", "Preferred aspect ratio; 8:7 PAR|4:3" },
@@ -757,8 +766,13 @@ void retro_get_system_info(struct retro_system_info *info)
 
 void retro_get_system_av_info(struct retro_system_av_info *info)
 {
-   unsigned width = use_overscan ? 256 : (256 - 16);
-   unsigned height = use_overscan ? 240 : (240 - 16);
+#ifdef PSP
+    unsigned width  = use_overscan ? 256 : (256 - 16);
+    unsigned height = use_overscan ? 240 : (240 - 16);
+#else
+    unsigned width  = 256 - (overscan_h ? 16 : 0);
+    unsigned height = 240 - (overscan_v ? 16 : 0);0;
+#endif
    info->geometry.base_width = width;
    info->geometry.base_height = height;
    info->geometry.max_width = width;
@@ -1040,6 +1054,7 @@ static void check_variables(bool startup)
       }
    }
 
+#ifdef PSP
    var.key = "fceumm_overscan";
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
@@ -1051,6 +1066,32 @@ static void check_variables(bool startup)
          geometry_update = true;
       }
    }
+
+#else
+   var.key = "fceumm_overscan_h";
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      bool newval = (!strcmp(var.value, "enabled"));
+      if (newval != overscan_h)
+      {
+         overscan_h = newval;
+         geometry_update = true;
+      }
+   }
+
+   var.key = "fceumm_overscan_v";
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      bool newval = (!strcmp(var.value, "enabled"));
+      if (newval != overscan_v)
+      {
+         overscan_v = newval;
+         geometry_update = true;
+      }
+   }
+#endif
 
    var.key = "fceumm_turbo_enable";
 
@@ -1240,19 +1281,12 @@ static void retro_run_blit(uint8_t *gfx)
    unsigned height = 240;
    unsigned pitch  = 512;
 
+#ifdef PSP
    if (!use_overscan)
    {
-      incr    = 16;
       width  -= 16;
       height -= 16;
-#ifndef PSP
-      pitch  -= 32;
-      gfx     = gfx + 8 + 256 * 8;
-
-#endif
    }
-
-#ifdef PSP
    texture_vram_p = (void*) (0x44200000 - (256 * 256)); // max VRAM address - frame size
 
    sceKernelDcacheWritebackRange(retro_palette,256 * 2);
@@ -1281,6 +1315,11 @@ static void retro_run_blit(uint8_t *gfx)
 
    video_cb(texture_vram_p, width, height, 256);
 #else
+   incr   += (overscan_h ? 16 : 0);
+   width  -= (overscan_h ? 16 : 0);
+   height -= (overscan_v ? 16 : 0);
+   pitch  -= (overscan_h ? 32 : 0);
+   gfx    += (overscan_v ? ((overscan_h ? 8 : 0) + 256 * 8) : (overscan_h ? 8 : 0));
    fb.width           = width;
    fb.height          = height;
    fb.access_flags    = RETRO_MEMORY_ACCESS_WRITE;


### PR DESCRIPTION
-This PR revamps the default overscan option and split this into separate horizontal and vertical overscan settings with with crop vertical as default, and non-crop on horizontal.
-Since PSP seems to have different retro_run settings for video and i have no device to test with, it is left alone and will still use the default use_overscan method.
