### PR TITLE
multiple palette related update and cleanup

### DIFF
--- a/src/drivers/libretro/libretro.c
+++ b/src/drivers/libretro/libretro.c
@@ -196,7 +196,7 @@ FILE *FCEUD_UTF8fopen(const char *n, const char *m)
 #define MAX_PATH 1024
 
 /*palette for FCEU*/
-#define MAXPAL 28 /* max # of palettes in array + 2 for "default" and "raw" */
+#define MAXPAL 23 /* raw palette # */
 int external_palette_exist = 0;
 
 struct st_palettes {
@@ -349,96 +349,6 @@ struct st_palettes palettes[] = {
 		   0xfcc4fc, 0xfcc4d8, 0xfcbcb0, 0xfcd8a8,
 		   0xfce4a0, 0xe0fca0, 0xa8f0bc, 0xb0fccc,
 		   0x9cfcf0, 0x000000, 0x000000, 0x000000 }
-   },
-   { "zaphod-cv", "Zaphod's VS Castlevania palette",
-	   { 0x7f7f7f, 0xffa347, 0x0000bf, 0x472bbf,
-		   0x970087, 0xf85898, 0xab1300, 0xf8b8f8,
-		   0xbf0000, 0x007800, 0x006b00, 0x005b00,
-		   0xffffff, 0x9878f8, 0x000000, 0x000000,
-		   0xbfbfbf, 0x0078f8, 0xab1300, 0x6b47ff,
-		   0x00ae00, 0xe7005b, 0xf83800, 0x7777ff,
-		   0xaf7f00, 0x00b800, 0x00ab00, 0x00ab47,
-		   0x008b8b, 0x000000, 0x000000, 0x472bbf,
-		   0xf8f8f8, 0xffe3ab, 0xf87858, 0x9878f8,
-		   0x0078f8, 0xf85898, 0xbfbfbf, 0xffa347,
-		   0xc800c8, 0xb8f818, 0x7f7f7f, 0x007800,
-		   0x00ebdb, 0x000000, 0x000000, 0xffffff,
-		   0xffffff, 0xa7e7ff, 0x5bdb57, 0xe75f13,
-		   0x004358, 0x0000ff, 0xe7005b, 0x00b800,
-		   0xfbdb7b, 0xd8f878, 0x8b1700, 0xffe3ab,
-		   0x00ffff, 0xab0023, 0x000000, 0x000000 }
-   },
-   { "zaphod-smb", "Zaphod's VS SMB palette",
-	   { 0x626a00, 0x0000ff, 0x006a77, 0x472bbf,
-		   0x970087, 0xab0023, 0xab1300, 0xb74800,
-		   0xa2a2a2, 0x007800, 0x006b00, 0x005b00,
-		   0xffd599, 0xffff00, 0x009900, 0x000000,
-		   0xff66ff, 0x0078f8, 0x0058f8, 0x6b47ff,
-		   0x000000, 0xe7005b, 0xf83800, 0xe75f13,
-		   0xaf7f00, 0x00b800, 0x5173ff, 0x00ab47,
-		   0x008b8b, 0x000000, 0x91ff88, 0x000088,
-		   0xf8f8f8, 0x3fbfff, 0x6b0000, 0x4855f8,
-		   0xf878f8, 0xf85898, 0x595958, 0xff009d,
-		   0x002f2f, 0xb8f818, 0x5bdb57, 0x58f898,
-		   0x00ebdb, 0x787878, 0x000000, 0x000000,
-		   0xffffff, 0xa7e7ff, 0x590400, 0xbb0000,
-		   0xf8b8f8, 0xfba7c3, 0xffffff, 0x00e3e1,
-		   0xfbdb7b, 0xffae00, 0xb8f8b8, 0xb8f8d8,
-		   0x00ff00, 0xf8d8f8, 0xffaaaa, 0x004000 }
-   },
-   { "vs-drmar", "VS Dr. Mario palette",
-	   { 0x5f97ff, 0x000000, 0x000000, 0x47009f,
-		   0x00ab00, 0xffffff, 0xabe7ff, 0x000000,
-		   0x000000, 0x000000, 0x000000, 0x000000,
-		   0xe7005b, 0x000000, 0x000000, 0x000000,
-		   0x5f97ff, 0x000000, 0x000000, 0x000000,
-		   0x000000, 0x8b7300, 0xcb4f0f, 0x000000,
-		   0xbcbcbc, 0x000000, 0x000000, 0x000000,
-		   0x000000, 0x000000, 0x000000, 0x000000,
-		   0x00ebdb, 0x000000, 0x000000, 0x000000,
-		   0x000000, 0xff9b3b, 0x000000, 0x000000,
-		   0x83d313, 0x000000, 0x3fbfff, 0x000000,
-		   0x0073ef, 0x000000, 0x000000, 0x000000,
-		   0x00ebdb, 0x000000, 0x000000, 0x000000,
-		   0x000000, 0x000000, 0xf3bf3f, 0x000000,
-		   0x005100, 0x000000, 0xc7d7ff, 0xffdbab,
-		   0x000000, 0x000000, 0x000000, 0x000000 }
-   },
-   { "vs-cv", "VS Castlevania palette",
-	   { 0xaf7f00, 0xffa347, 0x008b8b, 0x472bbf,
-		   0x970087, 0xf85898, 0xab1300, 0xf8b8f8,
-		   0xf83800, 0x007800, 0x006b00, 0x005b00,
-		   0xffffff, 0x9878f8, 0x00ab00, 0x000000,
-		   0xbfbfbf, 0x0078f8, 0xab1300, 0x6b47ff,
-		   0x000000, 0xe7005b, 0xf83800, 0x6b88ff,
-		   0xaf7f00, 0x00b800, 0x6b88ff, 0x00ab47,
-		   0x008b8b, 0x000000, 0x000000, 0x472bbf,
-		   0xf8f8f8, 0xffe3ab, 0xf87858, 0x9878f8,
-		   0x0078f8, 0xf85898, 0xbfbfbf, 0xffa347,
-		   0x004358, 0xb8f818, 0x7f7f7f, 0x007800,
-		   0x00ebdb, 0x000000, 0x000000, 0xffffff,
-		   0xffffff, 0xa7e7ff, 0x5bdb57, 0x6b88ff,
-		   0x004358, 0x0000ff, 0xe7005b, 0x00b800,
-		   0xfbdb7b, 0xffa347, 0x8b1700, 0xffe3ab,
-		   0xb8f818, 0xab0023, 0x000000, 0x007800 }
-   },
-   { "vs-smb", "VS SMB/VS Ice Climber palette",
-	   { 0xaf7f00, 0x0000ff, 0x008b8b, 0x472bbf,
-		   0x970087, 0xab0023, 0x0000ff, 0xe75f13,
-		   0xbfbfbf, 0x007800, 0x5bdb57, 0x005b00,
-		   0xf0d0b0, 0xffe3ab, 0x00ab00, 0x000000,
-		   0xbfbfbf, 0x0078f8, 0x0058f8, 0x6b47ff,
-		   0x000000, 0xe7005b, 0xf83800, 0xf87858,
-		   0xaf7f00, 0x00b800, 0x6b88ff, 0x00ab47,
-		   0x008b8b, 0x000000, 0x000000, 0x3fbfff,
-		   0xf8f8f8, 0x006b00, 0x8b1700, 0x9878f8,
-		   0x6b47ff, 0xf85898, 0x7f7f7f, 0xe7005b,
-		   0x004358, 0xb8f818, 0x0078f8, 0x58f898,
-		   0x00ebdb, 0xfbdb7b, 0x000000, 0x000000,
-		   0xffffff, 0xa7e7ff, 0xb8b8f8, 0xf83800,
-		   0xf8b8f8, 0xfba7c3, 0xffffff, 0x00ffff,
-		   0xfbdb7b, 0xffa347, 0xb8f8b8, 0xb8f8d8,
-		   0xb8f818, 0xf8d8f8, 0x000000, 0x007800 }
    },
    { "nintendo-vc", "Virtual Console palette",
 	   { 0x494949, 0x00006a, 0x090063, 0x290059,
@@ -729,7 +639,7 @@ void retro_set_controller_port_device(unsigned a, unsigned b)
 void retro_set_environment(retro_environment_t cb)
 {
    static const struct retro_variable vars[] = {
-      { "fceumm_palette", "Color Palette; default|asqrealc|loopy|quor|chris|matt|pasofami|crashman|mess|zaphod-cv|zaphod-smb|vs-drmar|vs-cv|vs-smb|nintendo-vc|yuv-v3|unsaturated-final|sony-cxa2025as-us|pal|bmf-final2|bmf-final3|smooth-fbx|composite-direct-fbx|pvm-style-d93-fbx|ntsc-hardware-fbx|nes-classic-fbx-fs|nescap|wavebeam|raw|custom" },
+      { "fceumm_palette", "Color Palette; default|asqrealc|loopy|quor|chris|matt|pasofami|crashman|mess|nintendo-vc|yuv-v3|unsaturated-final|sony-cxa2025as-us|pal|bmf-final2|bmf-final3|smooth-fbx|composite-direct-fbx|pvm-style-d93-fbx|ntsc-hardware-fbx|nes-classic-fbx-fs|nescap|wavebeam|raw|custom" },
       { "fceumm_nospritelimit", "No Sprite Limit; disabled|enabled" },
       { "fceumm_overclocking", "Overclocking; disabled|2x-Postrender|2x-VBlank" },
 #ifdef PSP
@@ -968,44 +878,34 @@ static void check_variables(bool startup)
          current_palette = 7;
       else if (!strcmp(var.value, "mess"))
          current_palette = 8;
-      else if (!strcmp(var.value, "zaphod-cv"))
-         current_palette = 9;
-      else if (!strcmp(var.value, "zaphod-smb"))
-         current_palette = 10;
-      else if (!strcmp(var.value, "vs-drmar"))
-         current_palette = 11;
-      else if (!strcmp(var.value, "vs-cv"))
-         current_palette = 12;
-      else if (!strcmp(var.value, "vs-smb"))
-         current_palette = 13;
       else if (!strcmp(var.value, "nintendo-vc"))
-         current_palette = 14;
+         current_palette = 9;
       else if (!strcmp(var.value, "yuv-v3"))
-         current_palette = 15;
+         current_palette = 10;
       else if (!strcmp(var.value, "unsaturated-final"))
-         current_palette = 16;
+         current_palette = 11;
       else if (!strcmp(var.value, "sony-cxa2025as-us"))
-         current_palette = 17;
+         current_palette = 12;
       else if (!strcmp(var.value, "pal"))
-         current_palette = 18;
+         current_palette = 13;
       else if (!strcmp(var.value, "bmf-final2"))
-         current_palette = 19;
+         current_palette = 14;
       else if (!strcmp(var.value, "bmf-final3"))
-         current_palette = 20;
+         current_palette = 15;
       else if (!strcmp(var.value, "smooth-fbx"))
-         current_palette = 21;
+         current_palette = 16;
       else if (!strcmp(var.value, "composite-direct-fbx"))
-         current_palette = 22;
+         current_palette = 17;
       else if (!strcmp(var.value, "pvm-style-d93-fbx"))
-         current_palette = 23;
+         current_palette = 18;
       else if (!strcmp(var.value, "ntsc-hardware-fbx"))
-         current_palette = 24;
+         current_palette = 19;
       else if (!strcmp(var.value, "nes-classic-fbx-fs"))
-         current_palette = 25;
+         current_palette = 20;
       else if (!strcmp(var.value, "nescap"))
-         current_palette = 26;
+         current_palette = 21;
       else if (!strcmp(var.value, "wavebeam"))
-         current_palette = 27;
+         current_palette = 22;
       else if (!strcmp(var.value, "raw"))
          current_palette = MAXPAL;
       else if (!strcmp(var.value, "custom"))

--- a/src/drivers/libretro/libretro.c
+++ b/src/drivers/libretro/libretro.c
@@ -597,9 +597,9 @@ static void retro_set_custom_palette (void)
    ipalette = 0;
    use_raw_palette = false;
 
-   if (current_palette == 0 || current_palette > MAXPAL)
+   if (current_palette == 0 || current_palette > MAXPAL || (GameInfo->type == GIT_VSUNI))
    {
-      if (current_palette > MAXPAL)
+      if (current_palette > MAXPAL && !(GameInfo->type == GIT_VSUNI))
       {
          if (external_palette_exist)
             ipalette = 1;
@@ -609,6 +609,10 @@ static void retro_set_custom_palette (void)
             FCEU_PrintError("Using default palette instead.\n");
          }
       }
+
+      if (GameInfo->type == GIT_VSUNI)
+         FCEU_PrintError("Cannot use custom palette with VS. System.\n");
+
       FCEU_ResetPalette();	/* Do palette reset*/
       return;
    }

--- a/src/drivers/libretro/libretro.c
+++ b/src/drivers/libretro/libretro.c
@@ -196,7 +196,7 @@ FILE *FCEUD_UTF8fopen(const char *n, const char *m)
 #define MAX_PATH 1024
 
 /*palette for FCEU*/
-#define MAXPAL 23 /* raw palette # */
+#define MAXPAL 16 /* raw palette # */
 int external_palette_exist = 0;
 
 struct st_palettes {
@@ -224,132 +224,6 @@ struct st_palettes palettes[] = {
 	      0xffe890, 0xf0f4a4, 0xc0ffc0, 0xacf4f0,
 	      0xa0e8ff, 0xc2c2c2, 0x202020, 0x101010 }
 	},
-   { "loopy", "Loopy's palette",
-	   { 0x757575, 0x271b8f, 0x0000ab, 0x47009f,
-		   0x8f0077, 0xab0013, 0xa70000, 0x7f0b00,
-		   0x432f00, 0x004700, 0x005100, 0x003f17,
-		   0x1b3f5f, 0x000000, 0x000000, 0x000000,
-		   0xbcbcbc, 0x0073ef, 0x233bef, 0x8300f3,
-		   0xbf00bf, 0xe7005b, 0xdb2b00, 0xcb4f0f,
-		   0x8b7300, 0x009700, 0x00ab00, 0x00933b,
-		   0x00838b, 0x000000, 0x000000, 0x000000,
-		   0xffffff, 0x3fbfff, 0x5f97ff, 0xa78bfd,
-		   0xf77bff, 0xff77b7, 0xff7763, 0xff9b3b,
-		   0xf3bf3f, 0x83d313, 0x4fdf4b, 0x58f898,
-		   0x00ebdb, 0x000000, 0x000000, 0x000000,
-		   0xffffff, 0xabe7ff, 0xc7d7ff, 0xd7cbff,
-		   0xffc7ff, 0xffc7db, 0xffbfb3, 0xffdbab,
-		   0xffe7a3, 0xe3ffa3, 0xabf3bf, 0xb3ffcf,
-		   0x9ffff3, 0x000000, 0x000000, 0x000000 }
-   },
-   { "quor", "Quor's palette",
-	   { 0x3f3f3f, 0x001f3f, 0x00003f, 0x1f003f,
-		   0x3f003f, 0x3f0020, 0x3f0000, 0x3f2000,
-		   0x3f3f00, 0x203f00, 0x003f00, 0x003f20,
-		   0x003f3f, 0x000000, 0x000000, 0x000000,
-		   0x7f7f7f, 0x405f7f, 0x40407f, 0x5f407f,
-		   0x7f407f, 0x7f4060, 0x7f4040, 0x7f6040,
-		   0x7f7f40, 0x607f40, 0x407f40, 0x407f60,
-		   0x407f7f, 0x000000, 0x000000, 0x000000,
-		   0xbfbfbf, 0x809fbf, 0x8080bf, 0x9f80bf,
-		   0xbf80bf, 0xbf80a0, 0xbf8080, 0xbfa080,
-		   0xbfbf80, 0xa0bf80, 0x80bf80, 0x80bfa0,
-		   0x80bfbf, 0x000000, 0x000000, 0x000000,
-		   0xffffff, 0xc0dfff, 0xc0c0ff, 0xdfc0ff,
-		   0xffc0ff, 0xffc0e0, 0xffc0c0, 0xffe0c0,
-		   0xffffc0, 0xe0ffc0, 0xc0ffc0, 0xc0ffe0,
-		   0xc0ffff, 0x000000, 0x000000, 0x000000 }
-   },
-   { "chris", "Chris Covell's palette",
-	   { 0x808080, 0x003DA6, 0x0012B0, 0x440096,
-		   0xA1005E, 0xC70028, 0xBA0600, 0x8C1700,
-		   0x5C2F00, 0x104500, 0x054A00, 0x00472E,
-		   0x004166, 0x000000, 0x050505, 0x050505,
-		   0xC7C7C7, 0x0077FF, 0x2155FF, 0x8237FA,
-		   0xEB2FB5, 0xFF2950, 0xFF2200, 0xD63200,
-		   0xC46200, 0x358000, 0x058F00, 0x008A55,
-		   0x0099CC, 0x212121, 0x090909, 0x090909,
-		   0xFFFFFF, 0x0FD7FF, 0x69A2FF, 0xD480FF,
-		   0xFF45F3, 0xFF618B, 0xFF8833, 0xFF9C12,
-		   0xFABC20, 0x9FE30E, 0x2BF035, 0x0CF0A4,
-		   0x05FBFF, 0x5E5E5E, 0x0D0D0D, 0x0D0D0D,
-		   0xFFFFFF, 0xA6FCFF, 0xB3ECFF, 0xDAABEB,
-		   0xFFA8F9, 0xFFABB3, 0xFFD2B0, 0xFFEFA6,
-		   0xFFF79C, 0xD7E895, 0xA6EDAF, 0xA2F2DA,
-		   0x99FFFC, 0xDDDDDD, 0x111111, 0x111111 }
-   },
-   { "matt", "Matthew Conte's palette",
-	   { 0x808080, 0x0000bb, 0x3700bf, 0x8400a6,
-		   0xbb006a, 0xb7001e, 0xb30000, 0x912600,
-		   0x7b2b00, 0x003e00, 0x00480d, 0x003c22,
-		   0x002f66, 0x000000, 0x050505, 0x050505,
-		   0xc8c8c8, 0x0059ff, 0x443cff, 0xb733cc,
-		   0xff33aa, 0xff375e, 0xff371a, 0xd54b00,
-		   0xc46200, 0x3c7b00, 0x1e8415, 0x009566,
-		   0x0084c4, 0x111111, 0x090909, 0x090909,
-		   0xffffff, 0x0095ff, 0x6f84ff, 0xd56fff,
-		   0xff77cc, 0xff6f99, 0xff7b59, 0xff915f,
-		   0xffa233, 0xa6bf00, 0x51d96a, 0x4dd5ae,
-		   0x00d9ff, 0x666666, 0x0d0d0d, 0x0d0d0d,
-		   0xffffff, 0x84bfff, 0xbbbbff, 0xd0bbff,
-		   0xffbfea, 0xffbfcc, 0xffc4b7, 0xffccae,
-		   0xffd9a2, 0xcce199, 0xaeeeb7, 0xaaf7ee,
-		   0xb3eeff, 0xdddddd, 0x111111, 0x111111 }
-   },
-   { "pasofami", "PasoFami/99 palette",
-	   { 0x7f7f7f, 0x0000ff, 0x0000bf, 0x472bbf,
-		   0x970087, 0xab0023, 0xab1300, 0x8b1700,
-		   0x533000, 0x007800, 0x006b00, 0x005b00,
-		   0x004358, 0x000000, 0x000000, 0x000000,
-		   0xbfbfbf, 0x0078f8, 0x0058f8, 0x6b47ff,
-		   0xdb00cd, 0xe7005b, 0xf83800, 0xe75f13,
-		   0xaf7f00, 0x00b800, 0x00ab00, 0x00ab47,
-		   0x008b8b, 0x000000, 0x000000, 0x000000,
-		   0xf8f8f8, 0x3fbfff, 0x6b88ff, 0x9878f8,
-		   0xf878f8, 0xf85898, 0xf87858, 0xffa347,
-		   0xf8b800, 0xb8f818, 0x5bdb57, 0x58f898,
-		   0x00ebdb, 0x787878, 0x000000, 0x000000,
-		   0xffffff, 0xa7e7ff, 0xb8b8f8, 0xd8b8f8,
-		   0xf8b8f8, 0xfba7c3, 0xf0d0b0, 0xffe3ab,
-		   0xfbdb7b, 0xd8f878, 0xb8f8b8, 0xb8f8d8,
-		   0x00ffff, 0xf8d8f8, 0x000000, 0x000000 }
-   },
-   { "crashman", "CrashMan's palette",
-	   { 0x585858, 0x001173, 0x000062, 0x472bbf,
-		   0x970087, 0x910009, 0x6f1100, 0x4c1008,
-		   0x371e00, 0x002f00, 0x005500, 0x004d15,
-		   0x002840, 0x000000, 0x000000, 0x000000,
-		   0xa0a0a0, 0x004499, 0x2c2cc8, 0x590daa,
-		   0xae006a, 0xb00040, 0xb83418, 0x983010,
-		   0x704000, 0x308000, 0x207808, 0x007b33,
-		   0x1c6888, 0x000000, 0x000000, 0x000000,
-		   0xf8f8f8, 0x267be1, 0x5870f0, 0x9878f8,
-		   0xff73c8, 0xf060a8, 0xd07b37, 0xe09040,
-		   0xf8b300, 0x8cbc00, 0x40a858, 0x58f898,
-		   0x00b7bf, 0x787878, 0x000000, 0x000000,
-		   0xffffff, 0xa7e7ff, 0xb8b8f8, 0xd8b8f8,
-		   0xe6a6ff, 0xf29dc4, 0xf0c0b0, 0xfce4b0,
-		   0xe0e01e, 0xd8f878, 0xc0e890, 0x95f7c8,
-		   0x98e0e8, 0xf8d8f8, 0x000000, 0x000000 }
-   },
-   { "mess", "MESS palette",
-	   { 0x747474, 0x24188c, 0x0000a8, 0x44009c,
-		   0x8c0074, 0xa80010, 0xa40000, 0x7c0800,
-		   0x402c00, 0x004400, 0x005000, 0x003c14,
-		   0x183c5c, 0x000000, 0x000000, 0x000000,
-		   0xbcbcbc, 0x0070ec, 0x2038ec, 0x8000f0,
-		   0xbc00bc, 0xe40058, 0xd82800, 0xc84c0c,
-		   0x887000, 0x009400, 0x00a800, 0x009038,
-		   0x008088, 0x000000, 0x000000, 0x000000,
-		   0xfcfcfc, 0x3cbcfc, 0x5c94fc, 0x4088fc,
-		   0xf478fc, 0xfc74b4, 0xfc7460, 0xfc9838,
-		   0xf0bc3c, 0x80d010, 0x4cdc48, 0x58f898,
-		   0x00e8d8, 0x000000, 0x000000, 0x000000,
-		   0xfcfcfc, 0xa8e4fc, 0xc4d4fc, 0xd4c8fc,
-		   0xfcc4fc, 0xfcc4d8, 0xfcbcb0, 0xfcd8a8,
-		   0xfce4a0, 0xe0fca0, 0xa8f0bc, 0xb0fccc,
-		   0x9cfcf0, 0x000000, 0x000000, 0x000000 }
-   },
    { "nintendo-vc", "Virtual Console palette",
 	   { 0x494949, 0x00006a, 0x090063, 0x290059,
 		   0x42004a, 0x490000, 0x420000, 0x291100,
@@ -639,7 +513,7 @@ void retro_set_controller_port_device(unsigned a, unsigned b)
 void retro_set_environment(retro_environment_t cb)
 {
    static const struct retro_variable vars[] = {
-      { "fceumm_palette", "Color Palette; default|asqrealc|loopy|quor|chris|matt|pasofami|crashman|mess|nintendo-vc|yuv-v3|unsaturated-final|sony-cxa2025as-us|pal|bmf-final2|bmf-final3|smooth-fbx|composite-direct-fbx|pvm-style-d93-fbx|ntsc-hardware-fbx|nes-classic-fbx-fs|nescap|wavebeam|raw|custom" },
+      { "fceumm_palette", "Color Palette; default|asqrealc|nintendo-vc|yuv-v3|unsaturated-final|sony-cxa2025as-us|pal|bmf-final2|bmf-final3|smooth-fbx|composite-direct-fbx|pvm-style-d93-fbx|ntsc-hardware-fbx|nes-classic-fbx-fs|nescap|wavebeam|raw|custom" },
       { "fceumm_nospritelimit", "No Sprite Limit; disabled|enabled" },
       { "fceumm_overclocking", "Overclocking; disabled|2x-Postrender|2x-VBlank" },
 #ifdef PSP
@@ -864,48 +738,34 @@ static void check_variables(bool startup)
          current_palette = 0;
       else if (!strcmp(var.value, "asqrealc"))
          current_palette = 1;
-      else if (!strcmp(var.value, "loopy"))
-         current_palette = 2;
-      else if (!strcmp(var.value, "quor"))
-         current_palette = 3;
-      else if (!strcmp(var.value, "chris"))
-         current_palette = 4;
-      else if (!strcmp(var.value, "matt"))
-         current_palette = 5;
-      else if (!strcmp(var.value, "pasofami"))
-         current_palette = 6;
-      else if (!strcmp(var.value, "crashman"))
-         current_palette = 7;
-      else if (!strcmp(var.value, "mess"))
-         current_palette = 8;
       else if (!strcmp(var.value, "nintendo-vc"))
-         current_palette = 9;
+         current_palette = 2;
       else if (!strcmp(var.value, "yuv-v3"))
-         current_palette = 10;
+         current_palette = 3;
       else if (!strcmp(var.value, "unsaturated-final"))
-         current_palette = 11;
+         current_palette = 4;
       else if (!strcmp(var.value, "sony-cxa2025as-us"))
-         current_palette = 12;
+         current_palette = 5;
       else if (!strcmp(var.value, "pal"))
-         current_palette = 13;
+         current_palette = 6;
       else if (!strcmp(var.value, "bmf-final2"))
-         current_palette = 14;
+         current_palette = 7;
       else if (!strcmp(var.value, "bmf-final3"))
-         current_palette = 15;
+         current_palette = 8;
       else if (!strcmp(var.value, "smooth-fbx"))
-         current_palette = 16;
+         current_palette = 9;
       else if (!strcmp(var.value, "composite-direct-fbx"))
-         current_palette = 17;
+         current_palette = 10;
       else if (!strcmp(var.value, "pvm-style-d93-fbx"))
-         current_palette = 18;
+         current_palette = 11;
       else if (!strcmp(var.value, "ntsc-hardware-fbx"))
-         current_palette = 19;
+         current_palette = 12;
       else if (!strcmp(var.value, "nes-classic-fbx-fs"))
-         current_palette = 20;
+         current_palette = 13;
       else if (!strcmp(var.value, "nescap"))
-         current_palette = 21;
+         current_palette = 14;
       else if (!strcmp(var.value, "wavebeam"))
-         current_palette = 22;
+         current_palette = 15;
       else if (!strcmp(var.value, "raw"))
          current_palette = MAXPAL;
       else if (!strcmp(var.value, "custom"))

--- a/src/general.c
+++ b/src/general.c
@@ -82,13 +82,10 @@ char *FCEU_MakeFName(int type, int id1, char *cd1)
          sprintf(tmp, "%s"PSS "disksys.rom", BaseDirectory);
          break;
       case FCEUMKF_PALETTE:
-         if (odirs[FCEUIOD_MISC])
-            sprintf(tmp, "%s"PSS "%s.pal", odirs[FCEUIOD_MISC], FileBase);
-         else
-            sprintf(tmp, "%s"PSS "gameinfo"PSS "%s.pal", BaseDirectory, FileBase);
+         sprintf(tmp, "%s"PSS "nes.pal", BaseDirectory);
          break;
       case FCEUMKF_FDS:
-            sprintf(tmp, "%s"PSS "%s.sav", SaveDirectory, FileBase);
+         sprintf(tmp, "%s"PSS "%s.sav", SaveDirectory, FileBase);
          break;
       default:
          break;

--- a/src/palette.c
+++ b/src/palette.c
@@ -182,7 +182,7 @@ static void CalculatePalette(void) {
 	WritePalette();
 }
 
-static int ipalette = 0;
+int ipalette = 0;
 
 void FCEU_LoadGamePalette(void) {
 	uint8 ptmp[192];

--- a/src/palette.h
+++ b/src/palette.h
@@ -6,6 +6,7 @@ typedef struct {
 } pal;
 
 extern pal *palo;
+extern int ipalette;
 void FCEU_ResetPalette(void);
 
 void FCEU_ResetPalette(void);


### PR DESCRIPTION
- **Allow loading external palette file**
`This will allow loading external palette file. Filename must be renamed to "nes.pal" and saved into <system> directory. `
`If nes.pal is not loaded, and custom palette is selected in core options, this automatically applies "default" as fallback palette instead of showing a black screen.`
- **Remove custom VS System palettes**
`Custom VS palettes does not have all the palettes for VS and does not seem to look anywhere near stock palette or its non-VS game counterparts. This does not look good too if selected on non VS roms.`
- **Remove other palettes**
`Other palettes includes the initial added palettes(big respect to the people behind the 1st commit as these where already added from the very start) that doesn't seem to have been updated or been used for other palette comparisons.`
- **VS. System uses default palette**
`With the addition of "default" palette, FCEUmm, aside from able to set default NTSC palette, it can also set the correct VS. System palette. Forcing this is needed as other palettes are not compatible anyways`

- Modifications and other edits are welcome.