### PR TITLE
Mapper9: Add support to M.Tysons Punchout (PC10) ranking feature

### DIFF
--- a/src/boards/mmc2and4.c
+++ b/src/boards/mmc2and4.c
@@ -22,7 +22,7 @@
 
 #include "mapinc.h"
 
-static uint8 is10;
+static uint8 is10, battery;
 static uint8 creg[4], latch0, latch1, preg, mirr;
 static uint8 *WRAM = NULL;
 static uint32 WRAMSIZE;
@@ -39,7 +39,6 @@ static SFORMAT StateRegs[] =
 
 static void Sync(void) {
 	if (is10) {
-		setprg8r(0x10, 0x6000, 0);
 		setprg16(0x8000, preg);
 		setprg16(0xC000, ~0);
 	} else {
@@ -48,6 +47,8 @@ static void Sync(void) {
 		setprg8(0xC000, ~1);
 		setprg8(0xE000, ~0);
 	}
+	if (battery)
+		setprg8r(0x10, 0x6000, 0);
 	setchr4(0x0000, creg[latch0]);
 	setchr4(0x1000, creg[latch1 + 2]);
 	setmirror(mirr);
@@ -55,11 +56,11 @@ static void Sync(void) {
 
 DECLFW(MMC2and4Write) {
 	switch (A & 0xF000) {
-	case 0xA000: preg = V; Sync(); break;
-	case 0xB000: creg[0] = V; Sync(); break;
-	case 0xC000: creg[1] = V; Sync(); break;
-	case 0xD000: creg[2] = V; Sync(); break;
-	case 0xE000: creg[3] = V; Sync(); break;
+	case 0xA000: preg = V & 0xF; Sync(); break;
+	case 0xB000: creg[0] = V & 0x1F; Sync(); break;
+	case 0xC000: creg[1] = V & 0x1F; Sync(); break;
+	case 0xD000: creg[2] = V & 0x1F; Sync(); break;
+	case 0xE000: creg[3] = V & 0x1F; Sync(); break;
 	case 0xF000: mirr = (V & 1) ^ 1; Sync(); break;
 	}
 }
@@ -92,7 +93,7 @@ static void MMC2and4Power(void) {
 	preg = 0;
 	latch0 = latch1 = 1;
 	Sync();
-	if (is10) {
+	if (battery) {
 		SetReadHandler(0x6000, 0x7FFF, CartBR);
 		SetWriteHandler(0x6000, 0x7FFF, CartBW);
 		FCEU_CheatAddRAM(WRAMSIZE >> 10, 0x6000, WRAM);
@@ -113,14 +114,7 @@ static void MMC2and4Close(void) {
 
 void Mapper9_Init(CartInfo *info) {
 	is10 = 0;
-	info->Power = MMC2and4Power;
-	PPU_hook = MMC2and4PPUHook;
-	GameStateRestore = StateRestore;
-	AddExState(&StateRegs, ~0, 0, 0);
-}
-
-void Mapper10_Init(CartInfo *info) {
-	is10 = 1;
+	battery = 0;
 	info->Power = MMC2and4Power;
 	info->Close = MMC2and4Close;
 	PPU_hook = MMC2and4PPUHook;
@@ -129,6 +123,26 @@ void Mapper10_Init(CartInfo *info) {
 	SetupCartPRGMapping(0x10, WRAM, WRAMSIZE, 1);
 	AddExState(WRAM, WRAMSIZE, 0, "WRAM");
 	if (info->battery) {
+		battery = 1;
+		info->SaveGame[0] = WRAM;
+		info->SaveGameLen[0] = WRAMSIZE;
+	}
+	GameStateRestore = StateRestore;
+	AddExState(&StateRegs, ~0, 0, 0);
+}
+
+void Mapper10_Init(CartInfo *info) {
+	is10 = 1;
+	battery = 0;
+	info->Power = MMC2and4Power;
+	info->Close = MMC2and4Close;
+	PPU_hook = MMC2and4PPUHook;
+	WRAMSIZE = 8192;
+	WRAM = (uint8*)FCEU_gmalloc(WRAMSIZE);
+	SetupCartPRGMapping(0x10, WRAM, WRAMSIZE, 1);
+	AddExState(WRAM, WRAMSIZE, 0, "WRAM");
+	if (info->battery) {
+		battery = 1;
 		info->SaveGame[0] = WRAM;
 		info->SaveGameLen[0] = WRAMSIZE;
 	}

--- a/src/ines-correct.h
+++ b/src/ines-correct.h
@@ -85,6 +85,7 @@
 	{0xf518dd58,	  7,		8},	/* Captain Skyhawk */
 	{0x84382231,	  9,		0},	/* Punch Out (J) */
 	{0xbe939fce,	  9,		1},	/* Punchout*/
+	{0x7b837fde,	  9,		1},	/* Mike Tyson's Punch-Out!! (PC10)*/
 	{0x345d3a1a,	 11,		1},	/* Castle of Deceit */
 	{0x5e66eaea,	 13,		1},	/* Videomation */
 	{0xcd373baa,	 14,	   -1},	/* Samurai Spirits (Rex Soft) */


### PR DESCRIPTION
Issue: Mike Tyson's Punchout (PC10) version supports ranking save feature. Currently the game hangs-up after the first match due to missing save feature in mapper.