### PR TITLE
updates

### DIFF
--- a/src/drivers/libretro/libretro.c
+++ b/src/drivers/libretro/libretro.c
@@ -1017,8 +1017,7 @@ void GetMouseData(uint32_t *zapdata)
    bottom      = 240;
    offscreen   = 0;
 #ifdef PSP
-   adjx        = use_overscan ? 8:0;
-   adjy        = use_overscan ? 8:0;
+   adjx = adjy = use_overscan ? 8:0;
 #else
    adjx        = overscan_h ? 8:0;
    adjy        = overscan_v ? 8:0;
@@ -1142,7 +1141,7 @@ static void FCEUD_UpdateInput(void)
    if (GameInfo->type == GIT_VSUNI)
       FCEU_VSUniSwap(&pad[0], &pad[1]);
 
-   JSReturn[0] = pad[0] | (pad[1] << 8) | (pad[1] << 16 | (pad[1] << 24);
+   JSReturn[0] = pad[0] | (pad[1] << 8) | (pad[2] << 16) | (pad[3] << 24);
 
    GetMouseData(&MouseData[0]);
 

--- a/src/drivers/libretro/libretro.c
+++ b/src/drivers/libretro/libretro.c
@@ -84,7 +84,7 @@ static volatile int nofocus = 0;
 
 static int32_t *sound = 0;
 static uint32_t JSReturn[2];
-static uint32_t MouseData[2];
+static uint32_t MouseData[3];
 static uint32_t current_palette = 0;
 
 int PPUViewScanline=0;

--- a/src/drivers/libretro/libretro.c
+++ b/src/drivers/libretro/libretro.c
@@ -1069,13 +1069,13 @@ unsigned char turbo_p1_toggle[] = { 0, 0 };
 static void FCEUD_UpdateInput(void)
 {
    unsigned p, i;
-   unsigned char pad[2];
+   unsigned char pad[4];
 
-   pad[0] = pad[1] = 0;
+   pad[0] = pad[1] = pad[2] = pad[3] = 0;
 
    poll_cb();
 
-   for (p = 0; p < 2; p++)
+   for (p = 0; p < 4; p++)
    {
       for ( i = 0; i < 8; i++)
          pad[p] |= input_cb(p, RETRO_DEVICE_JOYPAD, 0, bindmap[i].retro) ? bindmap[i].nes : 0;
@@ -1142,7 +1142,7 @@ static void FCEUD_UpdateInput(void)
    if (GameInfo->type == GIT_VSUNI)
       FCEU_VSUniSwap(&pad[0], &pad[1]);
 
-   JSReturn[0] = pad[0] | (pad[1] << 8);
+   JSReturn[0] = pad[0] | (pad[1] << 8) | (pad[1] << 16 | (pad[1] << 24);
 
    GetMouseData(&MouseData[0]);
 

--- a/src/drivers/libretro/libretro.c
+++ b/src/drivers/libretro/libretro.c
@@ -582,7 +582,7 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
    info->geometry.max_width = width;
    info->geometry.max_height = height;
    info->geometry.aspect_ratio = use_par ? NES_8_7_PAR : NES_4_3;
-   info->timing.sample_rate = 32050.0;
+   info->timing.sample_rate = 48000.0;
    if (FSettings.PAL || dendy)
       info->timing.fps = 838977920.0/16777215.0;
    else
@@ -637,7 +637,7 @@ static void retro_set_custom_palette(void)
                             * -ntsccol    : sets ntsc to default palette.
                             * If none of the above are true, then
                             * default palette will be used.
-                            * VS.System should always use default palette.
+                            * VS Uniystem should always use default palette.
                             */
       return;
    }
@@ -1595,7 +1595,7 @@ bool retro_load_game(const struct retro_game_info *game)
    FCEUI_Initialize();
 
    FCEUI_SetSoundVolume(256);
-   FCEUI_Sound(32050);
+   FCEUI_Sound(48000);
 
    GameInfo = (FCEUGI*)FCEUI_LoadGame(game->path, (uint8_t*)game->data, game->size);
    if (!GameInfo)
@@ -1621,7 +1621,7 @@ bool retro_load_game(const struct retro_game_info *game)
       FCEU_PrintError("Cannot find nes.pal from system directory.\n");
 
    if (GameInfo->type == GIT_VSUNI)
-      FCEU_PrintError("VS.System rom loaded, will use default palette.\n");
+      FCEU_PrintError("VS Unisystem rom loaded, will use default palette.\n");
 
    retro_set_custom_palette();
 

--- a/src/video.c
+++ b/src/video.c
@@ -74,6 +74,7 @@ void FCEU_PutImage(void)
 			FCEU_VSUniDraw(XBuf);
 	}
 	if (howlong) howlong--;
+	FCEU_DrawInput(XBuf);
 }
 
 void FCEU_PutImageDummy(void)


### PR DESCRIPTION
```
- set sample rate to 48000 Hz
- set volume to 150 from 100
- add core option to select sound quality (low, high, very high)
- enable zapper for player 1 and player 2. NES needs zapper connected 
  to player #2 port, VS-uni needs zapper connected at player 1 port. 
  VS. Duck Hunt will sound alarm if zapper is not connected.
- input data for player 3 and 4 is not enabled by default, is this safe to enable?
  or should be conditional due to performance reasons?

Edits and modifications is welcome.
```