### PR TITLE
Fix crashing when trying to connect a netplay session

### DIFF
--- a/src/drivers/libretro/libretro.c
+++ b/src/drivers/libretro/libretro.c
@@ -533,17 +533,19 @@ void retro_set_input_state(retro_input_state_t cb)
 
 void retro_set_controller_port_device(unsigned port, unsigned device)
 {
-   switch(device)
+   if (port < 2)  /* port #0 = player1/player3, port #1 = player2/player4 */
    {
-      case RETRO_DEVICE_JOYPAD:
-         FCEUI_SetInput(port, SI_GAMEPAD, &JSReturn[0], 0);
-         break;
-      case RETRO_DEVICE_MOUSE:
-         FCEUI_SetInput(port, SI_ZAPPER, &MouseData[0], 1);
-         break;
+       switch(device)
+       {
+          case RETRO_DEVICE_JOYPAD:
+             FCEUI_SetInput(port, SI_GAMEPAD, &JSReturn[0], 0);
+             break;
+          case RETRO_DEVICE_MOUSE:
+             FCEUI_SetInput(port, SI_ZAPPER, &MouseData[0], 1);
+             break;
+       }
    }
 }
-
 
 void retro_set_environment(retro_environment_t cb)
 {


### PR DESCRIPTION
FCEUmm can use 2 controller ports, port #0 handles players 1 and 3, port #1 handles players 2 and 4.
During a netplay session, retro_set_controller_port_device() is called multiple times assigning different ports causing the crash. This PR limits the number of ports to be assigned when the function is called.

The issue was noticed when connecting an Android device and Linux machine, does not happen though when connecting a Linux and Windows machine.

Modifications are welcome.