### PR TITLE
Update ines-correct.h

### DIFF
--- a/src/ines-correct.h
+++ b/src/ines-correct.h
@@ -255,6 +255,9 @@
 	{0x44c20420,	199,	   -1},	/* San Guo Zhi 2 (C) */
 	{0x4e1c1e3c,	206,		0},	/* Karnov */
 	{0x276237b3,	206,		0},	/* Karnov */
+	{0xa5e6baf9,	206,		1},	/* Dragon Slayer 4 - Drasle Family (Japan) */
+	{0x9d21fe96,	206,		1},	/* Lupin Sansei - Pandora no Isan (Japan) */
+	{0x2a01f9d1,	206,		1},	/* Wagyan Land (Japan) */
 	{0x7678f1d5,	207,		8},	/* Fudou Myouou Den */
 	{0x07eb2c12,	208,	   -1},	/* Street Fighter IV */
 	{0xdd8ced31,	209,	   -1},	/* Power Rangers 3 */


### PR DESCRIPTION
https://github.com/libretro/libretro-fceumm/issues/151
Added following games to database:

Dragon Slayer 4 - Drasle Family (Japan)
ROM CRC32:  0xa5e6baf9
Mapper #:  206
Mirroring: Vertical

Wagyan Land (Japan)
ROM CRC32:  0x2a01f9d1
Mapper #:  206
Mirroring: Vertical

Lupin Sansei - Pandora no Isan (Japan)
ROM CRC32:  0x9d21fe96
Mapper #:  206
Mirroring: Vertical