### PR TITLE
Show log when loading invalid or missing header in rom.

### DIFF
--- a/src/boards/datalatch.c
+++ b/src/boards/datalatch.c
@@ -21,7 +21,7 @@
 #include "mapinc.h"
 #include "../ines.h"
 
-static uint8 latche, latcheinit, bus_conflict;
+static uint8 latche, latcheinit, bus_conflict, _busc;
 static uint16 addrreg0, addrreg1;
 static uint8 *WRAM = NULL;
 static uint32 WRAMSIZE;
@@ -138,7 +138,12 @@ static void UNROMSync(void) {
 }
 
 void UNROM_Init(CartInfo *info) {
-	Latch_Init(info, UNROMSync, 0, 0x8000, 0xFFFF, 0, 1);
+	_busc = 1;
+
+	if (info->CRC32 == 0x86be4746) /*  Dooly Bravo Land (Korea) (Unl) */
+		_busc = 0;
+
+	Latch_Init(info, UNROMSync, 0, 0x8000, 0xFFFF, 0, _busc);
 }
 
 //------------------ Map 3 ---------------------------
@@ -151,7 +156,7 @@ static void CNROMSync(void) {
 
 void CNROM_Init(CartInfo *info) {
 	//TODO: move these to extended database when implemented.
-	int _busc, x;
+	int x;
 	uint64 partialmd5 = 0;
 	_busc = 1;
 	for (x = 0; x < 8; x++)

--- a/src/ines-correct.h
+++ b/src/ines-correct.h
@@ -48,6 +48,7 @@
 	{0xe1b260da,	  2,		1},	/* Argos no Senshi */
 	{0x1d0f4d6b,	  2,		1},	/* Black Bass thinging */
 	{0x266ce198,	  2,		1},	/* City Adventure Touch */
+	{0x86be4746,	  2,		1},	/* Dooly Bravo Land (Korea) (Unl) */
 	{0x804f898a,	  2,		1},	/* Dragon Unit */
 	{0x55773880,	  2,		1},	/* Gilligan's Island */
 	{0x6e0eb43e,	  2,		1},	/* Puss n Boots */

--- a/src/ines.c
+++ b/src/ines.c
@@ -657,7 +657,10 @@ int iNESLoad(const char *name, FCEUFILE *fp) {
 		return 0;
 
 	if (memcmp(&head, "NES\x1a", 4))
+	{
+		FCEU_PrintError("Missing header or invalid iNES format file!\n");
 		return 0;
+	}
 
 	memset(&iNESCart, 0, sizeof(iNESCart));
 


### PR DESCRIPTION
- Show error log when loading rom without header or invalid iNES format.
- Add support for Dooly Bravo Land (Korea) (Unl), and set this to use mapper 2 (or should this really be mapper 71?)