### PR TITLE
Mapper2: Change default behavior

### DIFF
--- a/src/boards/datalatch.c
+++ b/src/boards/datalatch.c
@@ -134,13 +134,14 @@ static void UNROMSync(void) {
 			setmirror(((latche >> 3) & 1) ^ 1);	/* Higway Star Hacked mapper to be redefined to another mapper */
 	} else
 #endif
+	setprg8r(0x10, 0x6000, 0);
 	setprg16(0x8000, latche);
 	setprg16(0xc000, ~0);
 	setchr8(0);
 }
 
 void UNROM_Init(CartInfo *info) {
-	Latch_Init(info, UNROMSync, 0, 0x8000, 0xFFFF, 0, 1);
+	Latch_Init(info, UNROMSync, 0, 0x8000, 0xFFFF, 1, 0);
 }
 
 /*------------------ Map 3 ---------------------------*/


### PR DESCRIPTION
-Change default behavior of bus conflict from enabled to disabled. 
-Enabled WRAM (and eventually save ram if battery bit is enabled). 

This changes should support unl,hacked or patched games better without affecting much of licensed games. A quick test done to No-Intro sets(mapper 2) does not seem to have any effect. Other emulators have this disabled by default.
Further testing is needed to identify which carts do need the bus conflict checks, unless a list is already available.

related issue: https://github.com/libretro/libretro-fceumm/issues/172
supporting docs:
https://wiki.nesdev.com/w/index.php/UxROM
https://wiki.nesdev.com/w/index.php/Bus_conflict
