### PR TITLE
Initialize save ram

### DIFF
--- a/src/fceu-memory.c
+++ b/src/fceu-memory.c
@@ -34,6 +34,7 @@ void *FCEU_gmalloc(uint32 size)
       FCEU_PrintError("Error allocating memory!  Doing a hard exit.");
       exit(1);
    }
+   memset(ret, 0, size);
    return ret;
 }
 
@@ -47,7 +48,7 @@ void *FCEU_malloc(uint32 size)
       FCEU_PrintError("Error allocating memory!");
       ret = 0;
    }
-
+   memset(ret, 0, size);
    return ret;
 }
 


### PR DESCRIPTION
This is sometimes uses as work ram. without initializing, issuing save state dumps random data on the WRAM section which is not related to the game loaded (i see url sometimes).
https://cdn.discordapp.com/attachments/393248579327754250/416403251827572754/Screenshot_2018-02-23_09-17-04.png

Some mappers (mmc1 for example) will not re-initialize s-ram when it needs to.