### PR TITLE
Add missing variable to save state

### DIFF
--- a/src/state.c
+++ b/src/state.c
@@ -76,6 +76,7 @@ SFORMAT SFCPUC[] = {
 	{ &X.tcount, 4 | RLSB, "ICoa" },
 	{ &X.count, 4 | RLSB, "ICou" },
 	{ &timestampbase, sizeof(timestampbase) | RLSB, "TSBS" },
+	{ &X.mooPI, 1, "MooP"},
 	{ 0 }
 };
 


### PR DESCRIPTION
Fixes https://github.com/libretro/libretro-fceumm/issues/191
NOTE:
previous save states are not compatible due to state size change.