### PR TITLE
NSW: dynamic cores

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -269,10 +269,10 @@ else ifeq ($(platform), wiiu)
 
 # Nintendo Switch (libtransistor)
 else ifeq ($(platform), switch)
-	EXT=a
-        TARGET := $(TARGET_NAME)_libretro_$(platform).$(EXT)
-        include $(LIBTRANSISTOR_HOME)/libtransistor.mk
-        STATIC_LINKING=1
+	EXT=so
+	TARGET := $(TARGET_NAME)_libretro_$(platform).$(EXT)
+	include $(LIBTRANSISTOR_HOME)/libtransistor.mk
+	LDFLAGS = $(LD_SHARED_LIBRARY_FLAGS) -ltransistor.lib.nro $(LIBTRANSISTOR_LIB_LDFLAGS) -E
 	EXTERNAL_ZLIB=1
 
 
@@ -602,6 +602,10 @@ ifeq ($(STATIC_LINKING),1)
 else
 	LD = link.exe
 endif
+else ifeq ($(platform), switch)
+	OBJOUT   = -o 
+	LINKOUT  = -o
+# libtransistor.mk sets LD for us
 else
 	OBJOUT   = -o
 	LINKOUT  = -o 


### PR DESCRIPTION
Tweaks the makefile to produce shared objects when compiling for switch. See libretro/RetroArch#6847.