### PR TITLE
Update input settings, allow multi-player without matching CRC

### DIFF
--- a/src/drivers/libretro/libretro.c
+++ b/src/drivers/libretro/libretro.c
@@ -649,14 +649,10 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
    {
       if (port < 2) /* player 1-2 */
       {
-         if (device != RETRO_DEVICE_AUTO) {
-            printf("Non-auto mode\n");
+         if (device != RETRO_DEVICE_AUTO)
             update_nes_controllers(port, device);
-         }
-         else {
-            printf("automatic mode\n");
+         else
             update_nes_controllers(port, nes_to_libretro(GameInfo->input[port]));
-         }
       }
       else
       {


### PR DESCRIPTION
Refactoring of input configurations for the following functions:
- allow players 1 upto 4 to select NES controller from UI -> **Input User 1-4 Binds**
- allow Famicom expansion controllers to be configured from **Input User 5 Binds**
- forcing Gamepad for Input User 3/4 Binds will automatically allow for multi-player supported NES titles even without CRC match.
- for famicom games, **4-Player Adapter** should be selected for Input User 5 Binds for multiplayer titles.
- **Auto** will automatically select pre-configure input config including multiplayer enabled games using crc matching.

closes https://github.com/libretro/libretro-fceumm/issues/228 and https://github.com/libretro/libretro-fceumm/issues/218