### PR TITLE
Updates

### DIFF
--- a/src/boards/famicombox.c
+++ b/src/boards/famicombox.c
@@ -75,7 +75,6 @@ static void SSSNROMPower(void) {
 	regs[0] = regs[1] = regs[2] = regs[3] = regs[4] = regs[5] = regs[6] = 0;
 	regs[7] = 0xff;
 	Sync();
-	memset(WRAM, 0x00, WRAMSIZE);
 /*	SetWriteHandler(0x0000,0x1FFF,SSSNROMRamWrite); */
 	SetReadHandler(0x0800, 0x1FFF, CartBR);
 	SetWriteHandler(0x0800, 0x1FFF, CartBW);

--- a/src/drivers/libretro/libretro.c
+++ b/src/drivers/libretro/libretro.c
@@ -718,6 +718,7 @@ void retro_set_environment(retro_environment_t cb)
       { "fceumm_zapper_mode", "Zapper Mode; lightgun|mouse" },
       { "fceumm_show_crosshair", "Show Crosshair; enabled|disabled" },
       { "fceumm_overclocking", "Overclocking; disabled|2x-Postrender|2x-VBlank" },
+      { "fceumm_ramstate", "RAM power up state (Restart); fill $ff|fill $00|random" },
       { NULL, NULL },
    };
 
@@ -1841,6 +1842,7 @@ static char slash = '/';
 #endif
 
 extern uint32_t iNESGameCRC32;
+extern int option_ramstate;
 
 bool retro_load_game(const struct retro_game_info *game)
 {
@@ -1903,9 +1905,24 @@ bool retro_load_game(const struct retro_game_info *game)
 
    struct retro_memory_descriptor descs[64];
    struct retro_memory_map        mmaps;
+   struct retro_variable          var = {0};
 
    if (!game)
       return false;
+
+   var.value = 0;
+   var.key = "fceumm_ramstate";
+
+   /* set this variable before calling PowerNES() */
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "random"))
+         option_ramstate = 2;
+      else if (!strcmp(var.value, "fill $00"))
+         option_ramstate = 1;
+      else
+         option_ramstate = 0;
+   }
 
    PowerNES();
    check_system_specs();

--- a/src/fceu.c
+++ b/src/fceu.c
@@ -381,6 +381,8 @@ void ResetNES(void)
 	X6502_Reset();
 }
 
+int option_ramstate = 0;
+
 void FCEU_MemoryRand(uint8 *ptr, uint32 size)
 {
 	int x = 0;
@@ -394,7 +396,14 @@ void FCEU_MemoryRand(uint8 *ptr, uint32 size)
 		*ptr = (x & 1) ? 0x55 : 0xAA;	/* F-15 Sity War HISCORE is screwed... */
 										/* 1942 SCORE/HISCORE is screwed... */
 #endif
-		*ptr = 0xFF;
+		uint8_t v;
+		switch (option_ramstate)
+		{
+		case 0: v = 0xff; break;
+		case 1: v = 0x00; break;
+		case 2: v = (uint8_t)rand(); break;
+		}
+		*ptr = v;
 		x++;
 		size--;
 		ptr++;

--- a/src/fds.c
+++ b/src/fds.c
@@ -715,13 +715,11 @@ int FDSLoad(const char *name, FCEUFILE *fp) {
 
 	CHRRAMSize = 8192;
 	CHRRAM = (uint8*)FCEU_gmalloc(CHRRAMSize);
-	memset(CHRRAM, 0, CHRRAMSize);
 	SetupCartCHRMapping(0, CHRRAM, CHRRAMSize, 1);
 	AddExState(CHRRAM, CHRRAMSize, 0, "CHRR");
 
 	FDSRAMSize = 32768;
 	FDSRAM = (uint8*)FCEU_gmalloc(FDSRAMSize);
-	memset(FDSRAM, 0, FDSRAMSize);
 	SetupCartPRGMapping(1, FDSRAM, FDSRAMSize, 1);
 	AddExState(FDSRAM, FDSRAMSize, 0, "FDSR");
 


### PR DESCRIPTION

**9d9c480, Add core option: RAM power up state**
- fills RAM with different values, 0xff(default), 0xff and random

**e07255c , Remove redundant memset() calls**
- some memset() calls are not needed after FCEU_gmalloc() and FCEU_malloc() since these functions already include initializing memory pointers to 0. 
