### PR TITLE
Add m114.1(boogerman), m281, bmc-80013b. Update m205. Disable kt-008 …

### DIFF
--- a/src/boards/bmc80013b.c
+++ b/src/boards/bmc80013b.c
@@ -1,0 +1,77 @@
+/* FCEUmm - NES/Famicom Emulator
+ *
+ * Copyright (C) 2019 Libretro Team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/* NES 2.0 Mapper 274 is used for the 90-in-1 Hwang Shinwei multicart.
+ * Its UNIF board name is BMC-80013-B.
+ * https://wiki.nesdev.com/w/index.php/NES_2.0_Mapper_274 */
+
+#include "mapinc.h"
+
+static uint8 regs[2], mode;
+
+static SFORMAT StateRegs[] =
+{
+	{ &regs[0], 1, "REG0" },
+	{ &regs[1], 1, "REG1" },
+	{ &mode, 1, "MODE" },
+	{ 0 }
+};
+
+static void Sync(void) {
+	if (mode & 0x02)
+		setprg16(0x8000, regs[0] & 0x0F | regs[1] & 0x70);
+	else
+		setprg16r(1, 0x8000, regs[0] & 0x03);
+	setprg16(0xC000, regs[1]);
+	SetupCartMirroring(((regs[0] >> 4) & 1) ^ 1, 1, NULL);
+}
+
+static DECLFW(BMC80013BWrite) {
+	uint8 reg = (A >> 13) & 0x03;
+	if (!reg)
+		regs[0] = V & 0x1F;
+	else {
+		regs[1] = V & 0x7F;
+		mode = reg;
+	}
+	Sync();
+}
+
+static void BMC80013BPower(void) {
+	Sync();
+	setchr8(0);
+	SetReadHandler(0x8000, 0xFFFF, CartBR);
+	SetWriteHandler(0x8000, 0xFFFF, BMC80013BWrite);
+}
+
+static void BMC80013BReset(void) {
+	regs[0] = regs[1] = mode = 0;
+	Sync();
+}
+
+static void BMC80013BRestore(int version) {
+	Sync();
+}
+
+void BMC80013B_Init(CartInfo *info) {
+	info->Power = BMC80013BPower;
+	info->Reset = BMC80013BReset;
+	GameStateRestore = BMC80013BRestore;
+	AddExState(&StateRegs, ~0, 0, 0);
+}

--- a/src/boards/mmc3.c
+++ b/src/boards/mmc3.c
@@ -236,8 +236,9 @@ static void GENPWRAP(uint32 A, uint8 V) {
    /* [NJ102] Mo Dao Jie (C) has 1024Mb MMC3 BOARD, maybe something other will be broken
     * also HengGe BBC-2x boards enables this mode as default board mode at boot up
     */
-   setprg8(A, (V & 0x7F) | ((kt_extra & 4) << 4));
+   setprg8(A, (V & 0x7F)/* | ((kt_extra & 4) << 4)*/);
    /* KT-008 boards hack 2-in-1, TODO assign to new ines mapper, most dump of KT-boards on the net are mapper 4, so need database or goodnes fix support */
+   /* KT-008 boards should be assigned to mapper 224 */
 }
 
 static void GENMWRAP(uint8 V) {
@@ -265,7 +266,7 @@ void GenMMC3Power(void) {
 	SetReadHandler(0x8000, 0xFFFF, CartBR);
 
    /* KT-008 boards hack 2-in-1, TODO assign to new ines mapper, most dump of KT-boards on the net are mapper 4, so need database or goodnes fix support */
-   SetWriteHandler(0x5000,0x5FFF, KT008HackWrite);
+   /* SetWriteHandler(0x5000,0x5FFF, KT008HackWrite); */   /* KT-008 boards should be assigned to mapper 224 */
 
 	A001B = A000B = 0;
 	setmirror(1);
@@ -321,6 +322,7 @@ void GenMMC3_Init(CartInfo *info, int prg, int chr, int wram, int battery) {
 	}
 
    /* KT-008 boards hack 2-in-1, TODO assign to new ines mapper, most dump of KT-boards on the net are mapper 4, so need database or goodnes fix support */
+   /* KT-008 boards should be assigned to mapper 224 */
    AddExState(&kt_extra, 1, 0, "KTEX");
 	AddExState(MMC3_StateRegs, ~0, 0, 0);
 
@@ -720,18 +722,24 @@ void Mapper74_Init(CartInfo *info) {
 
 /* ---------------------------- Mapper 114 ------------------------------ */
 
-static uint8 cmdin;
+static uint8 cmdin, type_Boogerman = 0;
+uint8 boogerman_perm[8] = { 0, 2, 5, 3, 6, 1, 7, 4 };
 uint8 m114_perm[8] = { 0, 3, 1, 5, 6, 7, 2, 4 };
 
 static void M114PWRAP(uint32 A, uint8 V) {
 	if (EXPREGS[0] & 0x80) {
-/*		FCEU_printf("8000-C000:%02X\n",EXPREGS[0]&0xF); */
-		setprg16(0x8000, EXPREGS[0] & 0xF);
-		setprg16(0xC000, EXPREGS[0] & 0xF);
-	} else {
-/*		FCEU_printf("%04X:%02X\n",A,V&0x3F); */
-		setprg8(A, V & 0x3F);
-	}
+		if (EXPREGS[0] & 0x20)
+			setprg32(0x8000, (EXPREGS[0] & 0x0F) >> 1);
+		else {
+			setprg16(0x8000, (EXPREGS[0] & 0x0F));
+			setprg16(0xC000, (EXPREGS[0] & 0x0F));
+		}
+	} else
+		setprg8(A, V);
+}
+
+static void M114CWRAP(uint32 A, uint8 V) {
+	setchr1(A, (uint32)V | ((EXPREGS[1] & 1) << 8));
 }
 
 static DECLFW(M114Write) {
@@ -746,28 +754,52 @@ static DECLFW(M114Write) {
 	}
 }
 
+static DECLFW(BoogermanWrite) {
+	switch (A & 0xE001) {
+	case 0x8001: if (!cmdin) break; MMC3_CMDWrite(0x8001, V); cmdin = 0; break;
+	case 0xA000: MMC3_CMDWrite(0x8000, (V & 0xC0) | (boogerman_perm[V & 7])); cmdin = 1; break;
+	case 0xA001: IRQReload = 1; break;
+	case 0xC000: MMC3_CMDWrite(0xA000, V); break;
+	case 0xC001: IRQLatch = V; break;
+	case 0xE000: X6502_IRQEnd(FCEU_IQEXT); IRQa = 0; break;
+	case 0xE001: IRQa = 1; break;
+	}
+}
+
 static DECLFW(M114ExWrite) {
 	if (A <= 0x7FFF) {
-		EXPREGS[0] = V;
+		if (A & 1)
+			EXPREGS[1] = V;
+		else
+			EXPREGS[0] = V;
 		FixMMC3PRG(MMC3_cmd);
 	}
 }
 
 static void M114Power(void) {
+	EXPREGS[0] = EXPREGS[1] = 0;
 	GenMMC3Power();
+	SetWriteHandler(0x6000, 0x7FFF, M114ExWrite);
 	SetWriteHandler(0x8000, 0xFFFF, M114Write);
-	SetWriteHandler(0x5000, 0x7FFF, M114ExWrite);
+	if (type_Boogerman)
+		SetWriteHandler(0x8000, 0xFFFF, BoogermanWrite);
 }
 
 static void M114Reset(void) {
-	EXPREGS[0] = 0;
+	EXPREGS[0] = EXPREGS[1] = 0;
 	MMC3RegReset();
 }
 
 void Mapper114_Init(CartInfo *info) {
 	isRevB = 0;
+	type_Boogerman = 0;
+	if (info->CRC32 == 0x80eb1839 ||	/* Boogerman (Sugar Softec) (Unl) [!] - submapper 1 */
+		info->CRC32 == 0x071e4ee8)		/* 114 test-rom https://forums.nesdev.com/viewtopic.php?f=3&t=17391 */
+		type_Boogerman = 1;
+
 	GenMMC3_Init(info, 256, 256, 0, 0);
 	pwrap = M114PWRAP;
+	cwrap = M114CWRAP;
 	info->Power = M114Power;
 	info->Reset = M114Reset;
 	AddExState(EXPREGS, 1, 0, "EXPR");
@@ -1137,22 +1169,21 @@ void Mapper198_Init(CartInfo *info) {
 }
 
 /* ---------------------------- Mapper 205 ------------------------------ */
-/* GN-45 BOARD */
+/* https://wiki.nesdev.com/w/index.php/INES_Mapper_205 */
 
 static void M205PW(uint32 A, uint8 V) {
-/* GN-30A - \ED\E0\F7\E0\EB\FC\ED\E0\FF \EC\E0\F1\EA\E0 \E4\EE\EB\E6\ED\E0 \E1\FB\F2\FC 1F + \E0\EF\EF\E0\F0\E0\F2\ED\FB\E9 \EF\E5\F0\E5\EA\EB\FE\F7\E0\F2\E5\EB\FC \ED\E0 \F8\E8\ED\E5 \E0\E4\F0\E5\F1\E0 */
-	setprg8(A, (V & 0x0f) | EXPREGS[0]);
+	setprg8(A, EXPREGS[0] & 0x30 | (V & (!(EXPREGS[0] & 0xC0) ? 0x1F : 0x0F)));
 }
 
 static void M205CW(uint32 A, uint8 V) {
-/* GN-30A - \ED\E0\F7\E0\EB\FC\ED\E0\FF \EC\E0\F1\EA\E0 \E4\EE\EB\E6\ED\E0 \E1\FB\F2\FC FF */
-	setchr1(A, (V & 0x7F) | (EXPREGS[0] << 3));
+	uint16 reg = (uint16)EXPREGS[0] & 0x30;
+	setchr1(A, (reg << 3) | V);
 }
 
 static DECLFW(M205Write0) {
-	if (EXPREGS[2] == 0) {
-		EXPREGS[0] = A & 0x30;
-		EXPREGS[2] = A & 0x80;
+	if (EXPREGS[1] == 0) {
+		EXPREGS[0] = (V << 4) & 0x30;
+		EXPREGS[1] = A & 0x80;
 		FixMMC3PRG(MMC3_cmd);
 		FixMMC3CHR(MMC3_cmd);
 	} else
@@ -1160,8 +1191,8 @@ static DECLFW(M205Write0) {
 }
 
 static DECLFW(M205Write1) {
-	if (EXPREGS[2] == 0) {
-		EXPREGS[0] = V & 0x30;
+	if (EXPREGS[1] == 0) {
+		EXPREGS[0] = V & 0xF0;
 		FixMMC3PRG(MMC3_cmd);
 		FixMMC3CHR(MMC3_cmd);
 	} else
@@ -1169,11 +1200,12 @@ static DECLFW(M205Write1) {
 }
 
 static void M205Reset(void) {
-	EXPREGS[0] = EXPREGS[2] = 0;
+	EXPREGS[0] = EXPREGS[1] = 0;
 	MMC3RegReset();
 }
 
 static void M205Power(void) {
+	EXPREGS[0] = EXPREGS[1] = 0;
 	GenMMC3Power();
 	SetWriteHandler(0x6000, 0x6fff, M205Write0);
 	SetWriteHandler(0x7000, 0x7fff, M205Write1);	/* OK-411 boards, the same logic, but data latched, 2-in-1 frankenstein */
@@ -1185,6 +1217,58 @@ void Mapper205_Init(CartInfo *info) {
 	cwrap = M205CW;
 	info->Power = M205Power;
 	info->Reset = M205Reset;
+	AddExState(EXPREGS, 1, 0, "EXPR");
+}
+
+/* --------------------------- GN-45 BOARD ------------------------------ */
+
+/* Mapper 361 and 366, previously assigned as Mapper 205 */
+static void GN45PW(uint32 A, uint8 V) {
+/* GN-30A - \ED\E0\F7\E0\EB\FC\ED\E0\FF \EC\E0\F1\EA\E0 \E4\EE\EB\E6\ED\E0 \E1\FB\F2\FC 1F + \E0\EF\EF\E0\F0\E0\F2\ED\FB\E9 \EF\E5\F0\E5\EA\EB\FE\F7\E0\F2\E5\EB\FC \ED\E0 \F8\E8\ED\E5 \E0\E4\F0\E5\F1\E0 */
+	setprg8(A, (V & 0x0f) | EXPREGS[0]);
+}
+
+static void GN45CW(uint32 A, uint8 V) {
+/* GN-30A - \ED\E0\F7\E0\EB\FC\ED\E0\FF \EC\E0\F1\EA\E0 \E4\EE\EB\E6\ED\E0 \E1\FB\F2\FC FF */
+	setchr1(A, (V & 0x7F) | (EXPREGS[0] << 3));
+}
+
+static DECLFW(GN45Write0) {
+	if (EXPREGS[2] == 0) {
+		EXPREGS[0] = A & 0x30;
+		EXPREGS[2] = A & 0x80;
+		FixMMC3PRG(MMC3_cmd);
+		FixMMC3CHR(MMC3_cmd);
+	} else
+		CartBW(A, V);
+}
+
+static DECLFW(GN45Write1) {
+	if (EXPREGS[2] == 0) {
+		EXPREGS[0] = V & 0x30;
+		FixMMC3PRG(MMC3_cmd);
+		FixMMC3CHR(MMC3_cmd);
+	} else
+		CartBW(A, V);
+}
+
+static void GN45Reset(void) {
+	EXPREGS[0] = EXPREGS[2] = 0;
+	MMC3RegReset();
+}
+
+static void GN45Power(void) {
+	GenMMC3Power();
+	SetWriteHandler(0x6000, 0x6fff, GN45Write0);
+	SetWriteHandler(0x7000, 0x7fff, GN45Write1);	/* OK-411 boards, the same logic, but data latched, 2-in-1 frankenstein */
+}
+
+void GN45_Init(CartInfo *info) {
+	GenMMC3_Init(info, 128, 128, 8, 0);
+	pwrap = GN45PW;
+	cwrap = GN45CW;
+	info->Power = GN45Power;
+	info->Reset = GN45Reset;
 	AddExState(EXPREGS, 1, 0, "EXPR");
 }
 

--- a/src/ines-correct.h
+++ b/src/ines-correct.h
@@ -167,7 +167,7 @@
 	{0x0d98db53,	114,	   -1},	/* Pocahontas */
 	{0x4e7729ff,	114,	   -1},	/* Super Donkey Kong */
 	{0xc5e5c5b2,	115,	   -1},	/* Bao Qing Tian (As).nes */
-	{0xa1dc16c0,	116,	   -1},	/* Street Heroes (Sachen) [b1] */
+/*	{0xa1dc16c0,	116,	   -1},	Street Heroes (Sachen) [b1] */
 	{0xe40dfb7e,	116,	   -1},	/* Somari (P conf.) */
 	{0xc9371ebb,	116,	   -1},	/* Somari (W conf.) */
 	{0x78b657ac,	118,	   -1},	/* Armadillo */
@@ -322,7 +322,6 @@
 	{0x4d735cb1,    224,        0}, /* Pokemon Platinum (KT-008 PCB)(Ch)[!] */
 	{0x4f427110,    224,        0}, /* Pokemon Platinum Alt title 1 (KT-008 PCB)(Ch)[!] */
 	{0xe001de16,    224,        0}, /* Pokemon Platinum Alt title 2 (KT-008 PCB)(Ch)[!] */
-
 	{0xbdbe3c96,    238,        1}, /* Contra Fighter (Unl) */
 	{0xcfe02ada,      1,       -1}, /* Darkman (E) [!] */
 	{0xcb53c523,      1,       -1}, /* King Neptune's Adventure (Color Dreams) [!] */
@@ -338,6 +337,25 @@
 	{0x99748230,    215,        0}, /* EarthWorm Jim 2 (SuperGame) */
 	{0x37876ac7,    215,        0}, /* Golden Card 6-in-1 (Unl) [!] */
 	{0x1a3320a3,    215,        0}, /* Mortal Kombat 3 (SuperGame) */
+	{0x80eb1839,    114,        0}, /* Boogerman (Sugar Softec) (Unl) [!] */
+	{0x071e4ee8,    114,        0}, /* m114,submapper 1 test rom */
+	{0xfe3e03a1,    197,       -1}, /* Mortal Kombat III Special (YY-030) (Ch) [!] */
+	{0x9151d311,    197,       -1}, /* Mortal Kombat III 28 Peoples (NT-328) (Ch) [!] */
+	{0xf6bd8e31,    281,        0}, /* 1997 Super HIK 4-in-1 (JY-052) [p1][!] */
+
+	/* ines mappers that uses iNes 2.0 numbers */
+
+	{0x5aa23a15,    361,        0}, /* 4-in-1 (OK-411)[p1][!] */
+	{0xf6b9d088,    366,        0}, /* 4-in-1 (K-3131GS, GN-45) [p1][!] */
+	{0x503566b2,    366,        0}, /* 4-in-1 (K-3131SS, GN-45) [p1][!] */
+
+	/* ines mappers that uses unif boards */
+
+	{0x0073dbd8,    260,       -1}, /* 2-in-1 - Mortal Kombat V Turbo 30 + Super Aladdin (Unl) [p1][!] */
+	{0x4dc6107d,    260,       -1}, /* 2-in-1 - Boogerman + Flintstones, The (Unl) [p1][!] */
+	{0xb72b2cf4,    260,       -1}, /* 2-in-1 - Aladdin + Lion King, The (Unl) [p1][!] */
+	{0xa1dc16c0,    262,       -1}, /* Street Heroes (Asia) (Ja) (Unl */
+	{0xf956fcea,    521,       -1}, /* Korean Igo (Korea) (Unl) */
 
 	{0x00000000,	  -1,	   -1}
 

--- a/src/ines.c
+++ b/src/ines.c
@@ -295,8 +295,8 @@ static void CheckHInfo(void) {
 	};
 	int32 tofix = 0, x;
 	uint64 partialmd5 = 0;
-	int current_mapper = 0;
-	int cur_mirr = 0;
+	int32 current_mapper = 0;
+	int32 cur_mirr = 0;
 
 	for (x = 0; x < 8; x++)
 		partialmd5 |= (uint64)iNESCart.MD5[15 - x] << (x * 8);
@@ -312,10 +312,10 @@ static void CheckHInfo(void) {
 					VROM = NULL;
 					tofix |= 8;
 				}
-				if (MapperNo != (moo[x].mapper & 0xFF)) {
+				if (MapperNo != (moo[x].mapper & 0xFFF)) {
 					tofix |= 1;
 					current_mapper = MapperNo;
-					MapperNo = moo[x].mapper & 0xFF;
+					MapperNo = moo[x].mapper & 0xFFF;
 				}
 			}
 			if (moo[x].mirror >= 0) {
@@ -598,7 +598,7 @@ static BMAPPINGLocal bmap[] = {
 	{(uint8_t*)"",					202, Mapper202_Init},
 	{(uint8_t*)"",					203, Mapper203_Init},
 	{(uint8_t*)"",					204, Mapper204_Init},
-	{(uint8_t*)"",					205, Mapper205_Init},
+	{(uint8_t*)"BMC 15-in-1/3-in-1",		205, Mapper205_Init},
 	{(uint8_t*)"NAMCOT 108 Rev. C",	206, Mapper206_Init},	/* Deprecated, Used to be "DEIROM" whatever it means, but actually simple version of MMC3 */
 	{(uint8_t*)"TAITO X1-005 Rev. B",	207, Mapper207_Init},
 	{(uint8_t*)"",					208, Mapper208_Init},
@@ -649,6 +649,13 @@ static BMAPPINGLocal bmap[] = {
 	{(uint8_t*)"DRAGON BALL PIRATE",	253, Mapper253_Init},
 	{(uint8_t*)"",					254, Mapper254_Init},
 	{(uint8_t*)"",					255, Mapper255_Init}, /* Duplicate of M225? */
+
+	{(uint8_t*)"BMC-HPxx",				260, BMCHPxx_Init},
+	{(uint8_t*)"UNL-SHERO",				262, UNLSHeroes_Init},
+	{(uint8_t*)"OK-411",				361, GN45_Init}, /* OK-411 is emulated together with GN-45 */
+	{(uint8_t*)"HUMMER/JY-052",			281, Mapper281_Init},
+	{(uint8_t*)"GN-45",				366, GN45_Init},
+	{(uint8_t*)"DREAMTECH01",			521, DreamTech01_Init},
 
 	{(uint8_t*)"",					0, NULL}
 };

--- a/src/ines.h
+++ b/src/ines.h
@@ -229,4 +229,7 @@ void Mapper253_Init(CartInfo *);
 void Mapper254_Init(CartInfo *);
 void Mapper255_Init(CartInfo *);
 
+void GN45_Init(CartInfo *info); /* m361, m366 */
+void Mapper281_Init(CartInfo *);
+
 #endif

--- a/src/unif.c
+++ b/src/unif.c
@@ -467,10 +467,11 @@ static BMAPPING bmap[] = {
 	{ "60311C", BMC60311C_Init, 0 },
 	{ "WS", BMCWS_Init, 0 },
 	{ "HPxx", BMCHPxx_Init, 0 },
-
+	{ "HP2018-A", BMCHPxx_Init, 0 },
 	{ "CHINA_ER_SAN2", Mapper19_Init, 0 }, /* http://forums.nesdev.com/viewtopic.php?t=16465&p=216531 */
 	{ "WAIXING-FW01", Mapper227_Init, 0 }, /* https://wiki.nesdev.com/w/index.php/Talk:INES_Mapper_242 */
 	{ "WAIXING-FS005", BMCFK23C_Init, 0 }, /* https://wiki.nesdev.com/w/index.php/INES_Mapper_176 */
+	{ "80013-B", BMC80013B_Init, 0 },
 
 #ifdef COPYFAMI
 	{ "COPYFAMI_MMC3", MapperCopyFamiMMC3_Init, 0 },
@@ -555,7 +556,7 @@ static int InitializeBoard(void) {
 		}
 		x++;
 	}
-	FCEU_PrintError("Board type not supported.");
+	FCEU_PrintError("Board type not supported.", boardname);
 	return(0);
 }
 
@@ -617,7 +618,6 @@ int UNIFLoad(const char *name, FCEUFILE *fp) {
 
  aborto:
 
-	FCEU_printf(" Failed to initialize board %s\n", boardname);
 	FreeUNIF();
 	ResetUNIF();
 	return 0;

--- a/src/unif.h
+++ b/src/unif.h
@@ -157,6 +157,7 @@ void BMCF15_Init(CartInfo *info);
 void UNLRT01_Init(CartInfo *info);
 void BMC810131C_Init(CartInfo *info);
 void BMC8IN1_Init(CartInfo *info);
+void BMC80013B_Init(CartInfo *info);
 
 /* additional boards */
 void BMC60311C_Init(CartInfo *info);			/* m289 */


### PR DESCRIPTION
…hack on mmc3. Add a few games to ines-correct.h

- Support for Boogerman (SuperGame) Mapper 114, submapper 1
- Update Mapper 205 based on nesdev, move previous mapper 205 to separate GN-45 mapper with retained support to emulate OK-411
- Use nes-to-unif wrapper for some games which does not have nes 2.0 header.
- add unif board BMC-80013-B
- add mapper 281 (JY-052)
- disable KT-008 hack on mmc3. KT-008 boards should be assigned as Mapper 224. Fixes Final Fantasy X1/X2
- force-assign a few roms using ines-correct.h