### PR TITLE
Try to fix PS3 save state issue.

### DIFF
--- a/src/sound.c
+++ b/src/sound.c
@@ -1233,7 +1233,8 @@ SFORMAT FCEUSND_STATEINFO[] = {
  * issues loading states with this. Increasing it only helps a few games.
  * Disabling this state variable for Wii/WiiU/GC for now. */
 /* TODO: fix this for better runahead feature for big-endian */
-#ifndef GEKKO
+/* UPDATE: Try to ignore this for all big-endian for now */
+#ifndef MSB_FIRST
 	/* wave buffer is used for filtering, only need first 17 values from it */
 	{ &Wave, 32 * sizeof(int32), "WAVE"},
 #endif


### PR DESCRIPTION
In the past while fixing state problems i Wii, this section was the last one i found to be a problem as well. Ignoring this state variable fixes the last Wii state loading problem. PS3 has recently been reported as having state problems and could be similar issue. So, lets just ignore this state variable for all big-endian platforms.