### PR TITLE
makefile.libretro: fix automatic platform detection

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -18,17 +18,17 @@ RETROARCH_OBJECTS :=
 
 ifeq ($(platform),)
 	platform = unix
-	ifeq ($(shell uname -a),)
+	ifeq ($(shell uname -s),)
 		platform = win
-	else ifneq ($(findstring MINGW,$(shell uname -a)),)
+	else ifneq ($(findstring MINGW,$(shell uname -s)),)
 		platform = win
-	else ifneq ($(findstring Darwin,$(shell uname -a)),)
+	else ifneq ($(findstring Darwin,$(shell uname -s)),)
 		platform = osx
 		arch = intel
 		ifeq ($(shell uname -p),powerpc)
 			arch = ppc
 		endif
-	else ifneq ($(findstring win,$(shell uname -a)),)
+	else ifneq ($(findstring win,$(shell uname -s)),)
 		platform = win
 	endif
 endif


### PR DESCRIPTION
If the hostname contains `win`, using `uname -a` incorrectly detects the `platform` as Windows, even if the host is Linux/Unix.
Similar issues:
* https://github.com/libretro/libretro-vecx/issues/19
* https://github.com/libretro/mgba/commit/337fc06385f08ef610f3425cb6c16bac14064192