### PR TITLE
Buildfix

### DIFF
--- a/src/boards/BS110.c
+++ b/src/boards/BS110.c
@@ -22,40 +22,36 @@
 #include "mapinc.h"
 #include "mmc3.h"
 
+static uint8 *WRAM;
+static uint32 WRAMSIZE;
 
-extern uint8 *WRAM;
-extern uint32 WRAMSIZE;
-
-//extern uint8 *CHRRAM;
-//extern uint32 CHRRAMSIZE;
-
-uint8 mmc3_reg[8];
-uint8 exRegs[8];
-uint8 pointer;
-uint8 locked;
-uint8 readDIP;
-uint16 prgAND;
-uint16 chrAND;
-uint16 prgOR;
-uint16 chrOR;
-uint8 nrom;
-uint8 nrom128;
-uint8 dipswitch;
+static uint8 mmc3_reg[8];
+static uint8 exRegs[8];
+static uint8 pointer;
+static uint8 locked;
+static uint8 readDIP;
+static uint16 prgAND;
+static uint16 chrAND;
+static uint16 prgOR;
+static uint16 chrOR;
+static uint8 nrom;
+static uint8 nrom128;
+static uint8 dipswitch;
 
 
 static SFORMAT BS110_StateRegs[] =
 {
 	{ exRegs, 8, "REGS" },
-	{ mmc3_reg, 8, "MMC3R" },
-	{ &pointer, 1, "POINT" },
+	{ mmc3_reg, 8, "MREG" },
+	{ &pointer, 1, "PNT0" },
 	{ &readDIP, 1, "RDIP" },
-	{ &prgAND, 2 | FCEUSTATE_RLSB, "PRGAND" },
-	{ &chrAND, 2 | FCEUSTATE_RLSB, "CHRAND" },
-	{ &prgOR, 2 | FCEUSTATE_RLSB, "PRGOR" },
-	{ &chrOR, 2 | FCEUSTATE_RLSB, "CHROR" },
+	{ &prgAND, 2 | FCEUSTATE_RLSB, "PAND" },
+	{ &chrAND, 2 | FCEUSTATE_RLSB, "CAND" },
+	{ &prgOR, 2 | FCEUSTATE_RLSB, "PROR" },
+	{ &chrOR, 2 | FCEUSTATE_RLSB, "CHOR" },
 	{ &nrom, 1, "NROM" },
 	{ &nrom128, 1, "N128" },
-	{ &dipswitch, 1, "DIP" },
+	{ &dipswitch, 1, "DIP0" },
 	{ 0 }
 };
 
@@ -180,9 +176,6 @@ static void BS110Reset(void)
 	MMC3RegReset();
 }
 static void BS110Close(void) {
-	if (WRAM)
-		FCEU_gfree(WRAM);
-	WRAM = NULL;
 }
 
 void BS110_Init(CartInfo *info) {
@@ -197,11 +190,6 @@ void BS110_Init(CartInfo *info) {
 	WRAM = (uint8*)FCEU_gmalloc(WRAMSIZE);
 	SetupCartPRGMapping(0x10, WRAM, WRAMSIZE, 1);
 	AddExState(WRAM, WRAMSIZE, 0, "WRAM");
-
-	//CHRRAMSIZE = 8192;
-	//CHRRAM = (uint8*)FCEU_gmalloc(CHRRAMSIZE);
-	//SetupCartCHRMapping(0x10, CHRRAM, CHRRAMSIZE, 1);
-	//AddExState(CHRRAM, CHRRAMSIZE, 0, "CHRR");
 
 	AddExState(EXPREGS, 3, 0, "EXPR");
 	AddExState(BS110_StateRegs, ~0, 0, 0);

--- a/src/boards/Bs5652.c
+++ b/src/boards/Bs5652.c
@@ -24,39 +24,35 @@
 #include "mmc3.h"
 #include "crc32.h"
 
-extern uint8 *WRAM;
-extern uint32 WRAMSIZE;
+static uint8 *WRAM;
+static uint32 WRAMSIZE;
 
-//extern uint8 *CHRRAM;
-//extern uint32 CHRRAMSIZE;
-
-uint8 mmc3_reg[8];
-uint8 exRegs[8];
-uint8 pointer;
-uint8 locked;
-uint8 readDIP;
-uint16 prgAND;
-uint16 chrAND;
-uint16 prgOR;
-uint16 chrOR;
-uint8 nrom;
-uint8 nrom128;
-uint8 dipswitch;
-
+static uint8 mmc3_reg[8];
+static uint8 exRegs[8];
+static uint8 pointer;
+static uint8 locked;
+static uint8 readDIP;
+static uint16 prgAND;
+static uint16 chrAND;
+static uint16 prgOR;
+static uint16 chrOR;
+static uint8 nrom;
+static uint8 nrom128;
+static uint8 dipswitch;
 
 static SFORMAT BS5652_StateRegs[] =
 {
 	{ exRegs, 8, "REGS" },
-	{ mmc3_reg, 8, "MMC3R" },
-	{ &pointer, 1, "POINT" },
+	{ mmc3_reg, 8, "MREG" },
+	{ &pointer, 1, "PNT0" },
 	{ &readDIP, 1, "RDIP" },
-	{ &prgAND, 2 | FCEUSTATE_RLSB, "PRGAND" },
-	{ &chrAND, 2 | FCEUSTATE_RLSB, "CHRAND" },
-	{ &prgOR, 2 | FCEUSTATE_RLSB, "PRGOR" },
-	{ &chrOR, 2 | FCEUSTATE_RLSB, "CHROR" },
+	{ &prgAND, 2 | FCEUSTATE_RLSB, "PAND" },
+	{ &chrAND, 2 | FCEUSTATE_RLSB, "CAND" },
+	{ &prgOR, 2 | FCEUSTATE_RLSB, "PROR" },
+	{ &chrOR, 2 | FCEUSTATE_RLSB, "CHOR" },
 	{ &nrom, 1, "NROM" },
 	{ &nrom128, 1, "N128" },
-	{ &dipswitch, 1, "DIP" },
+	{ &dipswitch, 1, "DIP0" },
 	{ 0 }
 };
 
@@ -96,7 +92,7 @@ static void Bs5652CW(uint32 A, uint8 V) {
 static void Bs5652PW(uint32 A, uint8 V) {
 	if (nrom)
 	{
-		if (exRegs[3] & 0x8)// 20190504 up2
+		if (exRegs[3] & 0x8) /* 20190504 up2 */
 		{
 			if ((exRegs[1] >> 3) & 0x01)
 			{
@@ -237,15 +233,10 @@ void Bs5652_Init(CartInfo *info)
 	WRAM = (uint8*)FCEU_gmalloc(WRAMSIZE);
 	SetupCartPRGMapping(0x10, WRAM, WRAMSIZE, 1);
 	AddExState(WRAM, WRAMSIZE, 0, "WRAM");
-	
-	//CHRRAMSIZE = 8192;
-	//CHRRAM = (uint8*)FCEU_gmalloc(CHRRAMSIZE);
-	//SetupCartCHRMapping(0x10, CHRRAM, CHRRAMSIZE, 1);
-	//AddExState(CHRRAM, CHRRAMSIZE, 0, "CHRR");
 
 	unif_crc = CalcCRC32(0, PRGptr[0], PRGsize[0]);
 
-	if (unif_crc == 0xb97641b5) //Fix my own error, unif CHR 0 error
+	if (unif_crc == 0xb97641b5) /* Fix my own error, unif CHR 0 error */
 	{
 		if ((CHRsize[0] == 0x2000) && (CHRsize[1] > 0x2000))
 		{

--- a/src/boards/NC7000M.c
+++ b/src/boards/NC7000M.c
@@ -25,40 +25,36 @@
 #include "mmc3.h"
 
 
-extern uint8 *WRAM;
-extern uint32 WRAMSIZE;
+static uint8 *WRAM;
+static uint32 WRAMSIZE;
 
-//extern uint8 *CHRRAM;
-//extern uint32 CHRRAMSIZE;
-
-
-uint8 mmc3_reg[8];
-uint8 exRegs[8];
-uint8 pointer;
-uint8 locked;
-uint8 readDIP;
-uint16 prgAND;
-uint16 chrAND;
-uint16 prgOR;
-uint16 chrOR;
-uint8 nrom;
-uint8 nrom256;
-uint16	reg;
+static uint8 mmc3_reg[8];
+static uint8 exRegs[8];
+static uint8 pointer;
+static uint8 locked;
+static uint8 readDIP;
+static uint16 prgAND;
+static uint16 chrAND;
+static uint16 prgOR;
+static uint16 chrOR;
+static uint8 nrom;
+static uint8 nrom256;
+static uint16 reg;
 
 
 static SFORMAT NC7000M_StateRegs[] =
 {
 	{ exRegs, 8, "REGS" },
-	{ mmc3_reg, 8, "MMC3R" },
-	{ &pointer, 1, "POINT" },
+	{ mmc3_reg, 8, "MREG" },
+	{ &pointer, 1, "PNT0" },
 	{ &readDIP, 1, "RDIP" },
-	{ &prgAND, 2 | FCEUSTATE_RLSB, "PRGAND" },
-	{ &chrAND, 2 | FCEUSTATE_RLSB, "CHRAND" },
-	{ &prgOR, 2 | FCEUSTATE_RLSB, "PRGOR" },
-	{ &chrOR, 2 | FCEUSTATE_RLSB, "CHROR" },
+	{ &prgAND, 2 | FCEUSTATE_RLSB, "PAND" },
+	{ &chrAND, 2 | FCEUSTATE_RLSB, "CAND" },
+	{ &prgOR, 2 | FCEUSTATE_RLSB, "PROR" },
+	{ &chrOR, 2 | FCEUSTATE_RLSB, "CHOR" },
 	{ &nrom, 1, "NROM" },
 	{ &nrom256, 1, "N256" },
-	{ &reg, 2 | FCEUSTATE_RLSB, "REG" },
+	{ &reg, 2 | FCEUSTATE_RLSB, "REG0" },
 	{ 0 }
 };
 
@@ -187,11 +183,6 @@ void NC7000M_Init(CartInfo *info) {
 	WRAM = (uint8*)FCEU_gmalloc(WRAMSIZE);
 	SetupCartPRGMapping(0x10, WRAM, WRAMSIZE, 1);
 	AddExState(WRAM, WRAMSIZE, 0, "WRAM");
-	
-	//CHRRAMSIZE = 8192;
-	//CHRRAM = (uint8*)FCEU_gmalloc(CHRRAMSIZE);
-	//SetupCartCHRMapping(0x10, CHRRAM, CHRRAMSIZE, 1);
-	//AddExState(CHRRAM, CHRRAMSIZE, 0, "CHRR");
 
 	AddExState(EXPREGS, 3, 0, "EXPR");
 	AddExState(NC7000M_StateRegs, ~0, 0, 0);

--- a/src/boards/addrlatch.c
+++ b/src/boards/addrlatch.c
@@ -581,34 +581,31 @@ void BMCSA005A_Init(CartInfo *info) {
 	Latch_Init(info, BMCSA005ASync, NULL, 0x0000, 0x8000, 0xFFFF, 0);
 }
 
+/* -------------- 831019C J-2282 ------------------------ */
 
-//-------------- 831019C J-2282 ------------------------
+static void J2282Sync(void)
+{
+    setchr8(0);
 
-static void J2282Sync(void) {
-	setchr8(0);
+    if ((latche & 0x40)) {
+        uint8 bank = (latche >> 0) & 0x1F;
+        setprg16(0x8000, bank);
+        setprg16(0xC000, bank);
+    } else {
+        if (latche & 0x800) {
+            setprg8(0x6000, ((latche << 1) & 0x3F) | 3);
+        }
+        uint8 bank = (latche >> 1) & 0x1F;
+        setprg32(0x8000, bank);
+    }
 
-	if ((latche & 0x40))
-	{
-		uint8 bank = (latche >> 0) & 0x1F;
-		setprg16(0x8000, bank);
-		setprg16(0xC000, bank);
-	}
-	else
-	{
-      uint8 bank;
-
-		if (latche & 0x800)
-			setprg8(0x6000, ((latche << 1) & 0x3F) | 3);
-		bank = (latche >> 1) & 0x1F;
-		setprg32(0x8000, bank);
-	}
-
-	if (latche & 0x80)
-		setmirror(0);
-	else
-		setmirror(1);
+    if (latche & 0x80)
+        setmirror(0);
+    else
+        setmirror(1);
 }
 
-void J2282_Init(CartInfo *info) {
-	Latch_Init(info, J2282Sync, NULL, 0x0000, 0x8000, 0xFFFF, 0);
+void J2282_Init(CartInfo *info)
+{
+    Latch_Init(info, J2282Sync, NULL, 0x0000, 0x8000, 0xFFFF, 0);
 }

--- a/src/boards/hp898f.c
+++ b/src/boards/hp898f.c
@@ -30,8 +30,9 @@ static SFORMAT StateRegs[] =
 	{ 0 }
 };
 
-// submapper 1 The code for the original fceux
-// submapper 0 new HP898F code by dragon2snow,loong2snow from www.nesbbs.com
+/* submapper 1 The code for the original fceux
+ * submapper 0 new HP898F code by dragon2snow,loong2snow from www.nesbbs.com 
+ */
 static void Sync(void) {
 	
 	if (_submapper == 1)
@@ -69,8 +70,8 @@ static DECLFW(HP898FWrite) {
 
 static DECLFW(HP898FWriteEx) {
 	switch (A & 4) {
-	case 0:	regs[0] = V; break;//CHR
-	case 4:	regs[1] = (V & 0xC0) | ((V >> 2) & 6) | ((V & 0x20) ? 1 : 0); break;//PRG
+	case 0:	regs[0] = V; break; /* CHR */
+	case 4:	regs[1] = (V & 0xC0) | ((V >> 2) & 6) | ((V & 0x20) ? 1 : 0); break; /* PRG */
 	}
 	Sync();
 }

--- a/src/boards/super24.c
+++ b/src/boards/super24.c
@@ -25,7 +25,7 @@ static uint8 *CHRRAM = NULL;
 static int masko8[8] = { 63, 31, 15, 1, 3, 0, 0, 0 };
 
 static uint8 oldversion = 0;
-// this mapper is 176 rip mapper.
+/* this mapper is 176 rip mapper. */
 
 static void Super24PW(uint32 A, uint8 V) {
 	if (oldversion == 1)

--- a/src/boards/vrc2and4.c
+++ b/src/boards/vrc2and4.c
@@ -35,7 +35,7 @@ static uint16 acount = 0;
 static uint8 *WRAM = NULL;
 static uint32 WRAMSIZE;
 
-static uint8 *_CHRptr = NULL;//for 400k+128K Contra J
+static uint8 *_CHRptr = NULL; /* for 400k+128K Contra J */
 static uint32 _CHRsize;
 
 static uint8 prgMask = 0x1F;
@@ -225,13 +225,13 @@ static void StateRestore(int version) {
 }
 
 static void VRC24Close(void) {
-	if (WRAM)
-		FCEU_gfree(WRAM);
-	WRAM = NULL;
-	
-		if (_CHRptr)
-		FCEU_gfree(_CHRptr);
-	_CHRptr = NULL;
+    if (WRAM)
+        FCEU_gfree(WRAM);
+    WRAM = NULL;
+
+    if (_CHRptr)
+        FCEU_gfree(_CHRptr);
+    _CHRptr = NULL;
 }
 
 void Mapper22_Init(CartInfo *info) {
@@ -251,7 +251,7 @@ void VRC24_Init(CartInfo *info) {
 	prgreg[2] = ~1;
 	prgreg[3] = ~0;
 	
-	if (info->CRC32 == 0xa20ad5d6)//400K PRG+ 128K CHR
+	if (info->CRC32 == 0xa20ad5d6) /* 400K PRG+ 128K CHR */
 	{
 		prgreg[2] = 0x30;
 		prgreg[3] = 0x31;

--- a/src/drivers/libretro/libretro.c
+++ b/src/drivers/libretro/libretro.c
@@ -2203,8 +2203,9 @@ bool retro_load_game(const struct retro_game_info *game)
          i++;
        }
    }
-   // This doesn't map in 2004--2007 but those aren't really
-   // worthwhile to read from on a vblank anyway
+   /* This doesn't map in 2004--2007 but those aren't really
+    * worthwhile to read from on a vblank anyway 
+    */
    descs[i].flags = 0;
    descs[i].ptr = PPU;
    descs[i].offset = 0;
@@ -2214,16 +2215,18 @@ bool retro_load_game(const struct retro_game_info *game)
    descs[i].len = 4;
    descs[i].addrspace="PPUREG";
    i++;
-   // In the future, it would be good to map pattern tables 1 and 2,
-   // but these must be remapped often
+   /* In the future, it would be good to map pattern tables 1 and 2,
+    * but these must be remapped often
+    */
    /* descs[i] = (struct retro_memory_descriptor){0, ????, 0, 0x0000 | PPU_BIT, PPU_BIT, PPU_BIT, 0x1000, "PAT0"}; */
    /* i++; */
    /* descs[i] = (struct retro_memory_descriptor){0, ????, 0, 0x1000 | PPU_BIT, PPU_BIT, PPU_BIT, 0x1000, "PAT1"}; */
    /* i++; */
-   // Likewise it would be better to use "vnapage" for this but
-   // RetroArch API is inconvenient for handles like that, so we'll
-   // just blithely assume the client will handle mapping and that
-   // we'll ignore those carts that have extra NTARAM.
+   /* Likewise it would be better to use "vnapage" for this but
+    * RetroArch API is inconvenient for handles like that, so we'll
+    * just blithely assume the client will handle mapping and that
+    * we'll ignore those carts that have extra NTARAM.
+    */
    descs[i].flags = 0;
    descs[i].ptr = NTARAM;
    descs[i].offset = 0;
@@ -2242,7 +2245,7 @@ bool retro_load_game(const struct retro_game_info *game)
    descs[i].len = 0x020;
    descs[i].addrspace="PALRAM";
    i++;
-   // OAM doesn't really live anywhere in address space so I'll put it at 0x4000.
+   /* OAM doesn't really live anywhere in address space so I'll put it at 0x4000. */
    descs[i].flags = 0;
    descs[i].ptr = SPRAM;
    descs[i].offset = 0;

--- a/src/ines.c
+++ b/src/ines.c
@@ -528,7 +528,7 @@ static BMAPPINGLocal bmap[] = {
 /*	{(uint8_t*)"",					131, Mapper131_Init}, */
 	{(uint8_t*)"TXC/MGENIUS 22111",	132, UNL22211_Init},
 	{(uint8_t*)"SA72008",				133, SA72008_Init},
-	//{(uint8_t*)"MMC3 BMC PIRATE",		134, Mapper134_Init},	
+/*	{(uint8_t*)"MMC3 BMC PIRATE",		134, Mapper134_Init}, */
 	{(uint8_t*)"MMC3 BMC PIRATE",		134, Bs5652_Init},
 /*	{(uint8_t*)"",					135, Mapper135_Init}, */
 	{(uint8_t*)"TCU02",				136, TCU02_Init},


### PR DESCRIPTION
- use shorter strings for state names
- make variables static
- turn C++ comments to C comments
- cleanup dead code in boards