### PR TITLE
(3DS) Disable NTSC filter

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -225,6 +225,7 @@ else ifeq ($(platform), ctr)
 	CFLAGS += -fomit-frame-pointer -fstrict-aliasing -ffast-math
 	STATIC_LINKING=1
 	EXTERNAL_ZLIB=1
+	HAVE_NTSC=0
 
 # Raspberry Pi 1
 else ifeq ($(platform), rpi1)


### PR DESCRIPTION
Unfortunately, the awesome new NTSC filter that was just added to the core is too much for the 3DS. The console has very limited linear memory, and with the filter in place it makes the video buffer too large (resulting in disabled video - if it were any larger, it would hard crash the device).

Fortunately, @negativeExponent implemented the filter in an incredibly considerate fashion by placing it behind a compiler flag (very much appreciated!). This PR just disables `HAVE_NTSC` for 3DS, and now all is well.