### PR TITLE
Remove extraneous semicolons at top-level

### DIFF
--- a/src/boards/txcchip.c
+++ b/src/boards/txcchip.c
@@ -65,7 +65,7 @@ typedef struct {
 
 static TXC txc;
 
-static void Dummyfunc(void) { };
+static void Dummyfunc(void) { }
 static void (*WSync)(void) = Dummyfunc;
 
 static SFORMAT StateRegs[] =

--- a/src/sound.c
+++ b/src/sound.c
@@ -145,7 +145,7 @@ static char DMCHaveDMA = 0;
 static uint8 DMCDMABuf = 0;
 static char DMCHaveSample = 0;
 
-static void Dummyfunc(void) { };
+static void Dummyfunc(void) { }
 static void (*DoNoise)(void) = Dummyfunc;
 static void (*DoTriangle)(void) = Dummyfunc;
 static void (*DoPCM)(void) = Dummyfunc;


### PR DESCRIPTION
These are unnecessary and not strictly allowed in ISO C.