### PR TITLE
Save state fix

### DIFF
--- a/src/fceu-types.h
+++ b/src/fceu-types.h
@@ -39,7 +39,7 @@ typedef uint32_t uint32;
 typedef unsigned long long uint64;
 typedef long long int64;
 	#define GINLINE inline
-#elif MSVC
+#elif MSVC | _MSC_VER
 typedef __int64 int64;
 typedef unsigned __int64 uint64;
 	#define GINLINE		/* Can't declare a function INLINE

--- a/src/ines.c
+++ b/src/ines.c
@@ -844,7 +844,12 @@ static int iNES_Init(int num) {
 				AddExState(VROM, CHRRAMSize, 0, "CHRR");
 			}
 			if (head.ROM_type & 8)
-				AddExState(ExtraNTARAM, 2048, 0, "EXNR");
+			{
+				if (ExtraNTARAM != NULL)
+				{
+					AddExState(ExtraNTARAM, 2048, 0, "EXNR");
+				}
+			}
 			tmp->init(&iNESCart);
 			return 1;
 		}

--- a/src/state.c
+++ b/src/state.c
@@ -324,6 +324,8 @@ void ResetExState(void (*PreSave)(void), void (*PostSave)(void))
 
 void AddExState(void *v, uint32 s, int type, char *desc)
 {
+   /* prevent adding a terminator to the list if a NULL pointer was provided */
+   if (v == NULL) return;
    memset(SFMDATA[SFEXINDEX].desc, 0, sizeof(SFMDATA[SFEXINDEX].desc));
    if (desc)
       strncpy(SFMDATA[SFEXINDEX].desc, desc, sizeof(SFMDATA[SFEXINDEX].desc));


### PR DESCRIPTION
Fix a bug that breaks savestates.
If a NULL pointer is added to the extended save state information list, it is counted as a terminator, and the rest of the extended save state is not written.
This change prevents a NULL pointer from being added.