### PR TITLE
Add support for Konami Hyper Shot

### DIFF
--- a/src/drivers/libretro/libretro.c
+++ b/src/drivers/libretro/libretro.c
@@ -49,6 +49,7 @@
 #define RETRO_DEVICE_FC_OEKAKIDS RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_MOUSE,  3)
 #define RETRO_DEVICE_FC_SHADOW   RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_MOUSE,  4)
 #define RETRO_DEVICE_FC_4PLAYERS RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_JOYPAD, 2)
+#define RETRO_DEVICE_FC_HYPERSHOT RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_JOYPAD, 3)
 #define RETRO_DEVICE_FC_AUTO     RETRO_DEVICE_JOYPAD
 
 #define NES_WIDTH   256
@@ -765,6 +766,10 @@ static void update_nes_controllers(unsigned port, unsigned device)
          FCEUI_SetInputFC(SIFC_4PLAYER, &nes_input.JSReturn, 0);
          FCEU_printf(" Famicom Expansion: Famicom 4-Player Adapter\n");
          break;
+      case RETRO_DEVICE_FC_HYPERSHOT:
+         FCEUI_SetInputFC(SIFC_HYPERSHOT, nes_input.FamicomData, 0);
+         FCEU_printf(" Famicom Expansion: Konami Hyper Shot\n");
+         break;
       case RETRO_DEVICE_NONE:
       default:
          FCEUI_SetInputFC(SIFC_NONE, &Dummy, 0);
@@ -807,6 +812,8 @@ static unsigned fc_to_libretro(int d)
       return RETRO_DEVICE_FC_OEKAKIDS;
    case SIFC_4PLAYER:
       return RETRO_DEVICE_FC_4PLAYERS;
+   case SIFC_HYPERSHOT:
+      return RETRO_DEVICE_FC_HYPERSHOT;
    }
 
    return (RETRO_DEVICE_NONE);
@@ -918,6 +925,7 @@ void retro_set_environment(retro_environment_t cb)
       { "Auto",                  RETRO_DEVICE_FC_AUTO },
       { "Arkanoid",              RETRO_DEVICE_FC_ARKANOID },
       { "(Bandai) Hyper Shot",   RETRO_DEVICE_FC_SHADOW },
+      { "(Konami) Hyper Shot",   RETRO_DEVICE_FC_HYPERSHOT },
       { "Oeka Kids Tablet",      RETRO_DEVICE_FC_OEKAKIDS },
       { "4-Player Adapter",      RETRO_DEVICE_FC_4PLAYERS },
       { 0, 0 },
@@ -1719,6 +1727,37 @@ static void FCEUD_UpdateInput(void)
       case RETRO_DEVICE_FC_SHADOW:
          get_mouse_input(0, nes_input.FamicomData);
          break;
+      case RETRO_DEVICE_FC_HYPERSHOT:
+      {
+         static int toggle;
+         int i;
+
+         nes_input.FamicomData[0] = 0;
+         toggle ^= 1;
+         for (i = 0; i < 2; i++)
+         {
+            
+            if (input_cb(i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B))
+               nes_input.FamicomData[0] |= 0x02 << (i * 2);
+            else if (input_cb(i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y))
+            {
+               if (toggle)
+                  nes_input.FamicomData[0] |= 0x02 << (i * 2);
+               else
+                  nes_input.FamicomData[0] &= ~(0x02 << (i * 2));
+            }
+            if (input_cb(i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A))
+               nes_input.FamicomData[0] |= 0x04 << (i * 2);
+            else if (input_cb(i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X))
+            {
+               if (toggle)
+                  nes_input.FamicomData[0] |= 0x04 << (i * 2);
+               else
+                  nes_input.FamicomData[0] &= ~(0x04 << (i * 2));
+            }
+         }
+         break;
+      }
    }
 
    if (input_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2))


### PR DESCRIPTION
This is just a quick hook-up of the konami hyper shot controller.

-The Konami Hyper Shot is used (and required for gameplay) in the following games:

* Hyper Olympic (J) Konami (1985)
* Hyper Sports (J) Konami (1985)

Fix #439