### PR TITLE
Make mapper 59 always reset to menu. Add previous mapper 60 ROM files to iNES correction table.

### DIFF
--- a/src/boards/addrlatch.c
+++ b/src/boards/addrlatch.c
@@ -111,6 +111,10 @@ static DECLFR(BMCD1038Read) {
 static void BMCD1038Reset(void) {
 	dipswitch++;
 	dipswitch &= 3;
+	
+	/* Always reset to menu */
+	latche = 0;
+	BMCD1038Sync();
 }
 
 void BMCD1038_Init(CartInfo *info) {

--- a/src/boards/addrlatch.c
+++ b/src/boards/addrlatch.c
@@ -108,6 +108,12 @@ static DECLFR(BMCD1038Read) {
 		return CartBR(A);
 }
 
+static DECLFW(BMCD1038Write) {
+	/* Only recognize the latch write if the lock bit has not been set. Needed for NT-234 "Road Fighter" */
+	if (~latche & 0x200)
+		LatchWrite(A, V);
+}
+
 static void BMCD1038Reset(void) {
 	dipswitch++;
 	dipswitch &= 3;
@@ -117,9 +123,17 @@ static void BMCD1038Reset(void) {
 	BMCD1038Sync();
 }
 
+static void BMCD1038Power(void) {
+	LatchPower();
+	
+	/* Trap latch writes to enforce the "Lock" bit */
+	SetWriteHandler(0x8000, 0xFFFF, BMCD1038Write);
+}
+
 void BMCD1038_Init(CartInfo *info) {
 	Latch_Init(info, BMCD1038Sync, BMCD1038Read, 0x0000, 0x8000, 0xFFFF, 0);
 	info->Reset = BMCD1038Reset;
+	info->Power = BMCD1038Power;
 	AddExState(&dipswitch, 1, 0, "DIPSW");
 }
 

--- a/src/ines-correct.h
+++ b/src/ines-correct.h
@@ -242,6 +242,20 @@
 	{ 0x1500e835,   48, DEFAULT, DFAULT8, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* Jetsons, The - Cogswell's Caper (Japan).nes */
 	{ 0xe2c94bc2,   48, DEFAULT, DFAULT8, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* Super Bros 8 (Unl) [!].nes */
 	{ 0xa912b064,   51, DEFAULT, DFAULT8, 0, DEFAULT, DEFAULT, DEFAULT,   0x800 }, /* 11-in-1 Ball Games [p1][o1].nes (has CHR ROM when it shouldn't) */
+	{ 0x2e72a5d9,   59, DEFAULT, DFAULT8, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* 11-in-1 (66-in-1, 86-in-1, 63-in-1).nes */
+	{ 0x39f514fd,   59, DEFAULT, DFAULT8, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* 18 in 1 (118-in-1, 138-in-1, 198-in-1)VTxxxx.nes */
+	{ 0xd8b1f465,   59, DEFAULT, DFAULT8, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* 26-in-1 (36-in-1, 46-in-1,56-in-1) VT 335.nes */
+	{ 0xcf82fae9,   59, DEFAULT, DFAULT8, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* 28 in 1 (38-in-1, 48-in-1, 58-in1)VTxxxx.nes */
+	{ 0xa7a98698,   59, DEFAULT, DFAULT8, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* 28-in-1 (46-in-1, 63-in-1, 118-in-1)VT-5116.nes */
+	{ 0x21fd7143,   59, DEFAULT, DFAULT8, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* 41-in-1 (5-in-1,71-in-1)  VT345.nes */
+	{ 0x49ec88d6,   59, DEFAULT, DFAULT8, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* 42-in-1 NT-234 Bad Game Road Fighter.nes */
+	{ 0x60306f19,   59, DEFAULT, DFAULT8, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* 42-in-1 PCB 3840.nes */
+	{ 0x450cd86e,   59, DEFAULT, DFAULT8, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* 48-in-1 (62-in-1,73-in-1,88-in-1) VTxxx.nes */
+	{ 0xd774e041,   59, DEFAULT, DFAULT8, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* 50-in-1 (60-in-1,70-in-1,80-in-1) NT-113.nes */
+	{ 0x3c4e94f6,   59, DEFAULT, DFAULT8, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* 51-in-1 (61-in-1, 71-in-1, 81-in-1) VT5310.nes */
+	{ 0x0422ed44,   59, DEFAULT, DFAULT8, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* 7-in-1 (32-in-1,66-in-1,119-in-1) VT15004.nes */
+	{ 0x7efc0d2c,   59, DEFAULT, DFAULT8, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* 7-in-1 (5000-in-1, 999999999-in-1, 10000000-in-1)NC-07N.nes */
+	{ 0x6d92dff1,   59, DEFAULT, DFAULT8, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* TN 95-in-1 (6-in-1) [p1].nes */
 	{ 0x39ab0fc7,   64, DEFAULT, DFAULT8, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* Hard Drivin' (USA) (Proto) (Unl).nes */
 	{ 0xb19a55dd,   64, DEFAULT, DFAULT8, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* Road Runner (USA) (Unl).nes */
 	{ 0xf92be3ec,   64, DEFAULT, DEFAULT, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* Rolling Thunder (USA) (Unl).nes */

--- a/src/ines.c
+++ b/src/ines.c
@@ -472,7 +472,6 @@ INES_BOARD_BEGIN()
 	INES_BOARD( "UNLKS202",                  56, UNLKS202_Init          )
 	INES_BOARD( "SIMBPLE BMC PIRATE A",      57, Mapper57_Init          )
 	INES_BOARD( "SIMBPLE BMC PIRATE B",      58, BMCGK192_Init          )
-/*	INES_BOARD( "",                          59, Mapper59_Init         ) */ /* Check this out, update 2020-10-21 - formerly an incorrect implementation of T3H53 */
 	INES_BOARD( "BMC T3H53/D1038",           59, BMCD1038_Init          )
 	INES_BOARD( "Reset-based NROM-128 ",     60, Mapper60_Init          )
 	INES_BOARD( "20-in-1 KAISER Rev. A",     61, Mapper61_Init          )


### PR DESCRIPTION
- Make mapper 59 reset to menu instead of resetting the game.
- Because of the previous mapper 59/60 confusion, many mapper 59 ROM files are incorrectly set to 60. I added all of them that I could find to ines-correct.h.
- Add lock bit, necessary for NT-234's "Road Fighter".

Fixes issue #418