### PR TITLE
Mappers 162/163/164/558

### DIFF
--- a/src/boards/162.c
+++ b/src/boards/162.c
@@ -1,0 +1,101 @@
+/* FCE Ultra - NES/Famicom Emulator
+ *
+ * Copyright notice for this file:
+ *  Copyright (C) 2002 Xodnizel
+ *  Copyright (C) 2005 CaH4e3
+ *  Copyright (C) 2019 Libretro Team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/* Waixing FS304 PCB */
+
+#include "mapinc.h"
+#include "../ines.h"
+
+static uint8 reg[4];
+static SFORMAT StateRegs[] =
+{
+        { reg, 4, "REGS" },
+        { 0 }
+};
+
+static void sync()
+{
+   setprg32(0x8000, reg[2] <<4 | reg[0] &0x0C                                        /* PRG A17-A20 always normal from $5000 and $5200 */
+                  | ( reg[3] &0x04                ?         0x00 : 0x02)             /* PRG A16 is 1       if $5300.2=0                */
+		  | ( reg[3] &0x04                ?(reg[0] &0x02): 0x00)             /* PRG A16 is $5000.1 if %5300.2=1                */
+		  | (                 reg[3] &0x01?         0x00 : reg[1] >>1 &0x01) /* PRG A15 is $5100.1 if               $5300.0=0  */
+		  | (~reg[3] &0x04 && reg[3] &0x01?         0x01 : 0x00)             /* PRG A15 is 1       if $5300.2=0 and $5300.0=1  */
+		  | ( reg[3] &0x04 && reg[3] &0x01?(reg[0] &0x01): 0x00)             /* PRG A15 is $5000.0 if $5300.2=1 and $5300.0=1  */
+   );
+   setprg8r(0x10, 0x6000, 0);
+   if (~reg[0] &0x80)
+      setchr8(0);
+}
+
+static void hblank(void) {
+   if (reg[0] &0x80 && scanline <239)
+   {  /* Actual hardware cannot look at the current scanline number, but instead latches PA09 on PA13 rises. This does not seem possible with the current PPU emulation however. */
+      setchr4(0x0000, scanline>=127? 1: 0);
+      setchr4(0x1000, scanline>=127? 1: 0);
+   }
+   else
+      setchr8(0);
+}
+
+static DECLFR(readReg)
+{
+   return 0x00;
+}
+
+static DECLFW(writeReg)
+{
+   reg[A >>8 &3] = V;
+   sync();
+}
+
+static void power(void)
+{
+   memset(reg, 0, sizeof(reg));
+   sync();
+   SetReadHandler (0x5000, 0x57FF, readReg);
+   SetWriteHandler(0x5000, 0x57FF, writeReg);
+   SetReadHandler (0x6000, 0xFFFF, CartBR);
+   SetWriteHandler(0x6000, 0x7FFF, CartBW);
+}
+
+static void reset()
+{
+   memset(reg, 0, sizeof(reg));
+   sync();
+}
+
+void Mapper162_Init (CartInfo *info)
+{
+   uint32 WRAMSIZE = info->iNES2? (info->PRGRamSize + info->PRGRamSaveSize): 8192;
+   info->Power   = power;
+   info->Reset   = reset;
+   GameHBIRQHook = hblank;
+   AddExState(StateRegs, ~0, 0, 0);
+
+   uint8* WRAM = (uint8*) FCEU_gmalloc(WRAMSIZE);
+   SetupCartPRGMapping(0x10, WRAM, WRAMSIZE, 1);
+   FCEU_CheatAddRAM(WRAMSIZE >> 10, 0x6000, WRAM);
+   if (info->battery) {
+      info->SaveGame[0] = WRAM;
+      info->SaveGameLen[0] = WRAMSIZE;
+   }
+}

--- a/src/boards/162.c
+++ b/src/boards/162.c
@@ -49,8 +49,8 @@ static void sync()
 static void hblank(void) {
    if (reg[0] &0x80 && scanline <239)
    {  /* Actual hardware cannot look at the current scanline number, but instead latches PA09 on PA13 rises. This does not seem possible with the current PPU emulation however. */
-      setchr4(0x0000, scanline>=127? 1: 0);
-      setchr4(0x1000, scanline>=127? 1: 0);
+      setchr4(0x0000, scanline >=127? 1: 0);
+      setchr4(0x1000, scanline >=127? 1: 0);
    }
    else
       setchr8(0);
@@ -96,6 +96,6 @@ void Mapper162_Init (CartInfo *info)
    FCEU_CheatAddRAM(WRAMSIZE >> 10, 0x6000, WRAM);
    if (info->battery) {
       info->SaveGame[0] = WRAM;
-      info->SaveGameLen[0] = WRAMSIZE;
+      info->SaveGameLen[0] = info->PRGRamSaveSize;
    }
 }

--- a/src/boards/163.c
+++ b/src/boards/163.c
@@ -65,8 +65,8 @@ static DECLFW(writeReg)
    
    if (A &1)
    {
-      if (reg[1] &0x01 && ~V &0x01) reg[1] ^=0x04;  // If A0=1, flip feedback bit on falling edges of D0
-   }                                                // If A0=0, write to register
+      if (reg[1] &0x01 && ~V &0x01) reg[1] ^=0x04;  /* If A0=1, flip feedback bit on falling edges of D0 */
+   }                                                /* If A0=0, write to register */
    else
       reg[index] = V;
    sync();

--- a/src/boards/163.c
+++ b/src/boards/163.c
@@ -1,0 +1,106 @@
+/* FCE Ultra - NES/Famicom Emulator
+ *
+ * Copyright notice for this file:
+ *  Copyright (C) 2002 Xodnizel
+ *  Copyright (C) 2005 CaH4e3
+ *  Copyright (C) 2019 Libretro Team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/* Nanjing FC-001 PCB */
+
+#include "mapinc.h"
+#include "../ines.h"
+
+static uint8 reg[4];
+static SFORMAT StateRegs[] =
+{
+        { reg, 4, "REGS" },
+        { 0 }
+};
+
+static void sync()
+{
+   setprg32(0x8000, reg[2] <<4 | reg[0] &0xF | (reg[3] &0x04? 0x00: 0x03));
+   setprg8r(0x10, 0x6000, 0);
+   if (~reg[0] &0x80)
+      setchr8(0);
+}
+
+static void hblank(void) {
+   if (reg[0] &0x80 && scanline <239)
+   {  /* Actual hardware cannot look at the current scanline number, but instead latches PA09 on PA13 rises. This does not seem possible with the current PPU emulation however. */
+      setchr4(0x0000, scanline>=127? 1: 0);
+      setchr4(0x1000, scanline>=127? 1: 0);
+   }
+   else
+      setchr8(0);
+}
+
+static DECLFR(readReg)
+{
+   return ~reg[1] &0x04;
+}
+
+static DECLFW(writeReg)
+{
+   uint8 index = A >>8 &3;
+   
+   /* Swap bits of registers 0-2 again if the "swap bits" bit is set. Exclude register 2 on when PRG-ROM is 1 MiB. */
+   if (reg[3] &0x01 && index <= (ROM_size == 64? 1: 2))
+      V = V &~3 | V >>1 &1 | V <<1 &2;
+   
+   if (A &1)
+   {
+      if (reg[1] &0x01 && ~V &0x01) reg[1] ^=0x04;  // If A0=1, flip feedback bit on falling edges of D0
+   }                                                // If A0=0, write to register
+   else
+      reg[index] = V;
+   sync();
+}
+
+static void power(void)
+{
+   memset(reg, 0, sizeof(reg));
+   sync();
+   SetReadHandler (0x5000, 0x57FF, readReg);
+   SetWriteHandler(0x5000, 0x57FF, writeReg);
+   SetReadHandler (0x6000, 0xFFFF, CartBR);
+   SetWriteHandler(0x6000, 0x7FFF, CartBW);
+}
+
+static void reset()
+{
+   memset(reg, 0, sizeof(reg));
+   sync();
+}
+
+void Mapper163_Init (CartInfo *info)
+{
+   uint32 WRAMSIZE = info->iNES2? (info->PRGRamSize + info->PRGRamSaveSize): 8192;
+   info->Power   = power;
+   info->Reset   = reset;
+   GameHBIRQHook = hblank;
+   AddExState(StateRegs, ~0, 0, 0);
+
+   uint8* WRAM = (uint8*) FCEU_gmalloc(WRAMSIZE);
+   SetupCartPRGMapping(0x10, WRAM, WRAMSIZE, 1);
+   FCEU_CheatAddRAM(WRAMSIZE >> 10, 0x6000, WRAM);
+   if (info->battery) {
+      info->SaveGame[0] = WRAM;
+      info->SaveGameLen[0] = WRAMSIZE;
+   }
+}

--- a/src/boards/164.c
+++ b/src/boards/164.c
@@ -103,8 +103,7 @@ static void reset()
 
 void Mapper164_Init (CartInfo *info)
 {
-   uint32 WRAMSIZE = info->iNES2? (info->PRGRamSize + info->PRGRamSaveSize): 8192;
-   WRAMSIZE &=~0x7FF; /* Do not include EEPROM in the WRAM size */
+   uint32 WRAMSIZE = info->iNES2? (info->PRGRamSize + (info->PRGRamSaveSize &~0x7FF)): 8192;
    info->Power = power;
    info->Reset = reset;
    AddExState(StateRegs, ~0, 0, 0);

--- a/src/boards/164.c
+++ b/src/boards/164.c
@@ -1,7 +1,9 @@
 /* FCE Ultra - NES/Famicom Emulator
  *
  * Copyright notice for this file:
- *  Copyright (C) 2002 Xodnizel 2006 CaH4e3
+ *  Copyright (C) 2002 Xodnizel
+ *  Copyright (C) 2005 CaH4e3
+ *  Copyright (C) 2019 Libretro Team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,217 +18,103 @@
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- *
- * It seems that 162/163/164 mappers are the same mapper with just different
- * mapper modes enabled or disabled in software or hardware, need more nanjing
- * carts
  */
 
+/* Dongda PEC-9588 educational computer. Provides the same 1bpp all-points-addressable graphics mode.
+   Its chipset was later used for the Yancheng cy2000-3 PCB, used on most of the games that display "Union Bond" at the start.
+   Some of them also use the 1bpp mode for a few screens!
+*/
+
 #include "mapinc.h"
+#include "eeprom_93C66.h"
 
-static uint8 laststrobe, trigger;
 static uint8 reg[8];
-static uint8 *WRAM = NULL;
-static uint32 WRAMSIZE;
-
-static writefunc pcmwrite;
-
-static void (*WSync)(void);
-
+static uint8 eeprom_data[512];
 static SFORMAT StateRegs[] =
 {
-	{ &laststrobe, 1, "STB" },
-	{ &trigger, 1, "TRG" },
-	{ reg, 8, "REGS" },
-	{ 0 }
+        { reg,           8, "REGS" },
+        { eeprom_data, 512, "EEPR" },
+        { 0 }
 };
 
-static void Sync(void) {
-	setprg8r(0x10, 0x6000, 0);
-	setprg32(0x8000, (reg[0] << 4) | (reg[1] & 0xF));
-	setchr8(0);
+static void sync()
+{
+   uint8 prgLow  = reg[0] &0x0F | reg[0] >>1 &0x10;
+   uint8 prgHigh = reg[1] <<5;
+   switch (reg[0] >>5 &2 | reg[0] >>4 &1)
+   {
+      case 0: /* UNROM-512 */
+         setprg16(0x8000, prgHigh | prgLow);
+         setprg16(0xC000, prgHigh |   0x1F);
+         break;
+      case 1: /* Open Bus on Yancheng cy2000-3 PCB, expansion cartridge on the Dongda PEC-9588 */
+         break;
+      case 2: /* UNROM-448+64. Very strange mode, used for the LOGO program on the Dongda PEC-9588 */
+         setprg16(0x8000, prgHigh | prgLow);
+         setprg16(0xC000, prgHigh |(prgLow >=0x1C? 0x1C: 0x1E));
+         break;
+      case 3: /* UNROM-128 or BNROM */
+         if (prgLow &0x10)
+         {
+            setprg16(0x8000, prgHigh | prgLow <<1 &0x10 | prgLow &0x0F);
+            setprg16(0xC000, prgHigh | prgLow <<1 &0x10 |         0x0F);
+         }
+         else
+            setprg32(0x8000, prgHigh >>1 | prgLow);
+         break;
+   }
+   setprg8r(0x10, 0x6000, 0);
+
+   setchr8(0);
+   PEC586Hack = !!(reg[0] &0x80);
+
+   setmirror(reg[0] &0x10 && ~reg[3] &0x80? MI_H: MI_V);
+
+   eeprom_93C66_write(reg[2] &0x10, reg[2] &0x04, reg[2] &0x01);
 }
 
-static void StateRestore(int version) {
-	WSync();
+static DECLFR(readReg)
+{
+   return eeprom_93C66_read()? 0x00: 0x04;
 }
 
-static DECLFR(ReadLow) {
-	switch (A & 0x7700) {
-	case 0x5100: return reg[2] | reg[0] | reg[1] | (reg[3] ^ 0xff); break;
-	case 0x5500:
-		if (trigger)
-			return reg[2] | reg[1];   /* Lei Dian Huang Bi Ka Qiu Chuan Shuo (NJ046) may broke other games */
-		else
-			return 0;
-	}
-	return 4;
+static DECLFW(writeReg)
+{
+   reg[A >>8 &7] = V;
+   sync();
 }
 
-static void M163HB(void) {
-	if (reg[1] & 0x80) {
-		if (scanline == 239) {
-			setchr4(0x0000, 0);
-			setchr4(0x1000, 0);
-		} else if (scanline == 127) {
-			setchr4(0x0000, 1);
-			setchr4(0x1000, 1);
-		}
-#if 0
-			if(scanline>=127)     /* Hu Lu Jin Gang (NJ039) (Ch) [!] don't like it */
-			{
-				setchr4(0x0000,1);
-				setchr4(0x1000,1);
-			}
-			else
-			{
-				setchr4(0x0000,0);
-				setchr4(0x1000,0);
-			}
-#endif
-	}
+static void power(void)
+{
+   memset(reg, 0, sizeof(reg));
+   eeprom_93C66_init();
+   sync();
+   SetReadHandler (0x5400, 0x57FF, readReg);
+   SetWriteHandler(0x5000, 0x57FF, writeReg);
+   SetReadHandler (0x6000, 0xFFFF, CartBR);
+   SetWriteHandler(0x6000, 0x7FFF, CartBW);
 }
 
-static DECLFW(Write) {
-	switch (A & 0x7300) {
-	case 0x5100: reg[0] = V; WSync(); break;
-	case 0x5000: reg[1] = V; WSync(); break;
-	case 0x5300: reg[2] = V; break;
-	case 0x5200: reg[3] = V; WSync(); break;
-	}
+static void reset()
+{
+   memset(reg, 0, sizeof(reg));
+   sync();
 }
 
-static void Power(void) {
-	memset(reg, 0, 8);
-	reg[1] = 0xFF;
-	SetWriteHandler(0x5000, 0x5FFF, Write);
-	SetReadHandler(0x6000, 0xFFFF, CartBR);
-	SetWriteHandler(0x6000, 0x7FFF, CartBW);
-	FCEU_CheatAddRAM(WRAMSIZE >> 10, 0x6000, WRAM);
-	WSync();
-}
+void Mapper164_Init (CartInfo *info)
+{
+   uint32 WRAMSIZE = info->iNES2? (info->PRGRamSize + info->PRGRamSaveSize): 8192;
+   WRAMSIZE &=~0x7FF; /* Do not include EEPROM in the WRAM size */
+   info->Power = power;
+   info->Reset = reset;
+   AddExState(StateRegs, ~0, 0, 0);
 
-static void Close(void) {
-	if (WRAM)
-		FCEU_gfree(WRAM);
-	WRAM = NULL;
-}
+   uint8* WRAM = (uint8*) FCEU_gmalloc(WRAMSIZE);
+   SetupCartPRGMapping(0x10, WRAM, WRAMSIZE, 1);
+   FCEU_CheatAddRAM(WRAMSIZE >> 10, 0x6000, WRAM);
 
-void Mapper164_Init(CartInfo *info) {
-	info->Power = Power;
-	info->Close = Close;
-	WSync = Sync;
-
-	WRAMSIZE = 8192;
-	WRAM = (uint8*)FCEU_gmalloc(WRAMSIZE);
-	SetupCartPRGMapping(0x10, WRAM, WRAMSIZE, 1);
-	AddExState(WRAM, WRAMSIZE, 0, "WRAM");
-
-	if (info->battery) {
-		info->SaveGame[0] = WRAM;
-		info->SaveGameLen[0] = WRAMSIZE;
-	}
-
-	GameStateRestore = StateRestore;
-	AddExState(&StateRegs, ~0, 0, 0);
-}
-
-static DECLFW(Write2) {
-	if (A == 0x5101) {
-		if (laststrobe && !V) {
-			trigger ^= 1;
-		}
-		laststrobe = V;
-	} else if (A == 0x5100 && V == 6) /* damn those protected games */
-		setprg32(0x8000, 3);
-	else
-		switch (A & 0x7300) {
-		case 0x5200: reg[0] = V; WSync(); break;
-		case 0x5000: reg[1] = V; WSync(); if (!(reg[1] & 0x80) && (scanline < 128)) setchr8(0); /* setchr8(0); */ break;
-		case 0x5300: reg[2] = V; break;
-		case 0x5100: reg[3] = V; WSync(); break;
-		}
-}
-
-static void Power2(void) {
-	memset(reg, 0, 8);
-	laststrobe = 1;
-	pcmwrite = GetWriteHandler(0x4011);
-	SetReadHandler(0x5000, 0x5FFF, ReadLow);
-	SetWriteHandler(0x5000, 0x5FFF, Write2);
-	SetReadHandler(0x6000, 0xFFFF, CartBR);
-	SetWriteHandler(0x6000, 0x7FFF, CartBW);
-	FCEU_CheatAddRAM(WRAMSIZE >> 10, 0x6000, WRAM);
-	WSync();
-}
-
-void Mapper163_Init(CartInfo *info) {
-	info->Power = Power2;
-	info->Close = Close;
-	WSync = Sync;
-	GameHBIRQHook = M163HB;
-
-	WRAMSIZE = 8192;
-	WRAM = (uint8*)FCEU_gmalloc(WRAMSIZE);
-	SetupCartPRGMapping(0x10, WRAM, WRAMSIZE, 1);
-	AddExState(WRAM, WRAMSIZE, 0, "WRAM");
-
-	if (info->battery) {
-		info->SaveGame[0] = WRAM;
-		info->SaveGameLen[0] = WRAMSIZE;
-	}
-	GameStateRestore = StateRestore;
-	AddExState(&StateRegs, ~0, 0, 0);
-}
-
-static void Sync3(void) {
-	setchr8(0);
-	setprg8r(0x10, 0x6000, 0);
-	switch (reg[3] & 7) {
-	case 0:
-	case 2: setprg32(0x8000, (reg[0] & 0xc) | (reg[1] & 2) | ((reg[2] & 0xf) << 4)); break;
-	case 1:
-	case 3: setprg32(0x8000, (reg[0] & 0xc) | (reg[2] & 0xf) << 4); break;
-	case 4:
-	case 6: setprg32(0x8000, (reg[0] & 0xe) | ((reg[1] >> 1) & 1) | ((reg[2] & 0xf) << 4)); break;
-	case 5:
-	case 7: setprg32(0x8000, (reg[0] & 0xf) | ((reg[2] & 0xf) << 4)); break;
-	}
-}
-
-static DECLFW(Write3) {
-/*	FCEU_printf("bs %04x %02x\n",A,V); */
-	reg[(A >> 8) & 3] = V;
-	WSync();
-}
-
-static void Power3(void) {
-	reg[0] = 3;
-	reg[1] = 0;
-	reg[2] = 0;
-	reg[3] = 7;
-	SetWriteHandler(0x5000, 0x5FFF, Write3);
-	SetReadHandler(0x6000, 0xFFFF, CartBR);
-	SetWriteHandler(0x6000, 0x7FFF, CartBW);
-	FCEU_CheatAddRAM(WRAMSIZE >> 10, 0x6000, WRAM);
-	WSync();
-}
-
-void UNLFS304_Init(CartInfo *info) {
-	info->Power = Power3;
-	info->Close = Close;
-	WSync = Sync3;
-
-	WRAMSIZE = 8192;
-	WRAM = (uint8*)FCEU_gmalloc(WRAMSIZE);
-	SetupCartPRGMapping(0x10, WRAM, WRAMSIZE, 1);
-	AddExState(WRAM, WRAMSIZE, 0, "WRAM");
-
-	if (info->battery) {
-		info->SaveGame[0] = WRAM;
-		info->SaveGameLen[0] = WRAMSIZE;
-	}
-
-	GameStateRestore = StateRestore;
-	AddExState(&StateRegs, ~0, 0, 0);
+   eeprom_93C66_storage = eeprom_data;
+   info->battery = 1;
+   info->SaveGame[0] = eeprom_data;
+   info->SaveGameLen[0] = 512;
 }

--- a/src/boards/eeprom_93C66.c
+++ b/src/boards/eeprom_93C66.c
@@ -1,0 +1,135 @@
+#include "eeprom_93C66.h"
+
+uint8* eeprom_93C66_storage;
+uint8  eeprom_93C66_opcode;
+uint8  eeprom_93C66_data;
+uint16 eeprom_93C66_address;
+uint8  eeprom_93C66_state;
+uint8  eeprom_93C66_lastCLK;
+uint8  eeprom_93C66_writeEnabled;
+uint8  eeprom_93C66_output;
+
+#define OPCODE_MISC         0
+#define OPCODE_WRITE        1
+#define OPCODE_READ         2
+#define OPCODE_ERASE        3
+#define OPCODE_WRITEDISABLE 10
+#define OPCODE_WRITEALL     11
+#define OPCODE_ERASEALL     12
+#define OPCODE_WRITEENABLE  13
+
+#define STATE_STANDBY   0
+#define STATE_STARTBIT  1
+#define STATE_OPCODE    3
+#define STATE_ADDRESS   12
+#define STATE_DATA      20
+#define STATE_FINISHED  99
+
+void eeprom_93C66_init ()
+{
+   eeprom_93C66_address      =0;
+   eeprom_93C66_state        =STATE_STANDBY;
+   eeprom_93C66_lastCLK      =0;
+   eeprom_93C66_writeEnabled =0;
+}
+
+uint8 eeprom_93C66_read ()
+{
+   return eeprom_93C66_output;
+}
+
+void eeprom_93C66_write (uint8 CS, uint8 CLK, uint8 DAT)
+{
+   if (!CS && eeprom_93C66_state <= STATE_ADDRESS)
+      eeprom_93C66_state =STATE_STANDBY;
+   else
+   if (eeprom_93C66_state ==STATE_STANDBY && CS  && CLK)
+   {
+      eeprom_93C66_state =STATE_STARTBIT;
+      eeprom_93C66_opcode  =0;
+      eeprom_93C66_address =0;
+      eeprom_93C66_output  =1;
+   }
+   else
+   if (CLK && !eeprom_93C66_lastCLK)
+   {
+      if (eeprom_93C66_state >=STATE_STARTBIT && eeprom_93C66_state <STATE_OPCODE) 
+         eeprom_93C66_opcode  =(eeprom_93C66_opcode  <<1) | (DAT? 1: 0);
+      else
+      if (eeprom_93C66_state >=STATE_OPCODE   && eeprom_93C66_state <STATE_ADDRESS)
+         eeprom_93C66_address =(eeprom_93C66_address <<1) | (DAT? 1: 0);
+      else
+      if (eeprom_93C66_state >=STATE_ADDRESS  && eeprom_93C66_state <STATE_DATA)
+      {
+         if (eeprom_93C66_opcode ==OPCODE_WRITE || eeprom_93C66_opcode ==OPCODE_WRITEALL)
+            eeprom_93C66_data =(eeprom_93C66_data    <<1) | (DAT? 1: 0);
+         else
+         if (eeprom_93C66_opcode ==OPCODE_READ)
+         {
+            eeprom_93C66_output =!!(eeprom_93C66_data &0x80);
+            eeprom_93C66_data   =   eeprom_93C66_data <<1;
+         }
+      }
+      eeprom_93C66_state++;
+      if (eeprom_93C66_state ==STATE_ADDRESS) {
+         switch (eeprom_93C66_opcode)
+         {
+            case OPCODE_MISC:
+               eeprom_93C66_opcode =(eeprom_93C66_address >>7) + 10;
+               switch (eeprom_93C66_opcode)
+               {
+                  case OPCODE_WRITEDISABLE:
+                     eeprom_93C66_writeEnabled = 0;
+                     eeprom_93C66_state = STATE_FINISHED;
+                     break;
+                  case OPCODE_WRITEENABLE: 
+                     eeprom_93C66_writeEnabled = 1;
+                     eeprom_93C66_state = STATE_FINISHED;
+                     break;
+                  case OPCODE_ERASEALL:
+                     if (eeprom_93C66_writeEnabled) for (int i =0; i <512; i++) eeprom_93C66_storage[i] = 0xFF;
+                     eeprom_93C66_state = STATE_FINISHED;
+                     break;
+                  case OPCODE_WRITEALL:
+                     eeprom_93C66_address = 0;
+                     break;
+               }
+               break;
+            case OPCODE_ERASE:
+               if (eeprom_93C66_writeEnabled) eeprom_93C66_storage[eeprom_93C66_address] = 0xFF;
+               eeprom_93C66_state = STATE_FINISHED;
+               break;
+            case OPCODE_READ:
+               eeprom_93C66_data = eeprom_93C66_storage[eeprom_93C66_address++];
+               break;
+         }
+      }
+      else
+      if (eeprom_93C66_state ==STATE_DATA)
+      {
+         if (eeprom_93C66_opcode ==OPCODE_WRITE)
+	 {
+            eeprom_93C66_storage[eeprom_93C66_address++] = eeprom_93C66_data;
+            eeprom_93C66_state = STATE_FINISHED;
+         }
+	 else
+         if (eeprom_93C66_opcode ==OPCODE_WRITEALL)
+	 {
+            eeprom_93C66_storage[eeprom_93C66_address++] = eeprom_93C66_data;
+            eeprom_93C66_state = CS && eeprom_93C66_address <512? STATE_ADDRESS: STATE_FINISHED;
+         }
+	 else
+         if (eeprom_93C66_opcode ==OPCODE_READ)
+	 {
+            if (eeprom_93C66_address <512) eeprom_93C66_data = eeprom_93C66_storage[eeprom_93C66_address];
+            eeprom_93C66_state = CS && ++eeprom_93C66_address <=512? STATE_ADDRESS: STATE_FINISHED;
+         }
+      }
+      if (eeprom_93C66_state == STATE_FINISHED)
+      {
+         eeprom_93C66_output = 0;
+         eeprom_93C66_state = STATE_STANDBY;
+      }
+   }
+   eeprom_93C66_lastCLK = CLK;
+}

--- a/src/boards/eeprom_93C66.h
+++ b/src/boards/eeprom_93C66.h
@@ -1,0 +1,10 @@
+#ifndef _EEPROM_93C66_H
+#define _EEPROM_93C66_H
+#include "mapinc.h"
+
+extern uint8* eeprom_93C66_storage;
+
+void  eeprom_93C66_init  ();
+uint8 eeprom_93C66_read  ();
+void  eeprom_93C66_write (uint8 CS, uint8 CLK, uint8 DAT);
+#endif

--- a/src/ines-correct.h
+++ b/src/ines-correct.h
@@ -37,7 +37,8 @@
 
 	{ 0xaf5d7aa2,    0, DEFAULT,    MI_H, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* Clu Clu Land (W) [o3].nes */
 	{ 0xcfb224e6,  222, DEFAULT,    MI_H, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* Dragon Ninja (J) (PRG0) [p1][!].nes */
-	{ 0x82f204ae,  163, DEFAULT,    MI_H, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* Liang Shan Ying Xiong (NJ023) (Ch) [!].nes */
+	{ 0x82f204ae,  162, DEFAULT,    MI_H, 0,    0x70,    0x07, DEFAULT, NOEXTRA }, /* Liang Shan Ying Xiong (NJ023) (Ch) [!].nes */
+	{ 0x8589652D,  162, DEFAULT,    MI_H, 0,    0x70,    0x07, DEFAULT, NOEXTRA }, /* 农场小精灵.nes */
 	{ 0xad9c63e2,   70, DEFAULT,    MI_V, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* Space Shadow (Japan).nes */
 	{ 0xe1526228,  206, DEFAULT,    MI_V, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* Ki no Bouken - The Quest of Ki (Japan).nes */
 	{ 0xaf5d7aa2,    0, DEFAULT,    MI_H, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* Clu Clu Land (W) [o3].nes */
@@ -355,7 +356,6 @@
 	{ 0x183859d2,  159, DEFAULT, DEFAULT, 1,    0x10, DEFAULT, DEFAULT, NOEXTRA }, /* Dragon Ball Z - Kyoushuu! Saiya Jin (Japan).nes */
 	{ 0x58152b42,  160, DEFAULT,    MI_V, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* Pipe V (Asia) (Ja) (Unl).nes */
 	{ 0x1c098942,  162, DEFAULT, DEFAULT, 1, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* Xi You Ji Hou Zhuan (Ch).nes */
-	{ 0x081caaff,  163, DEFAULT, DEFAULT, 1, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* Commandos (Ch).nes */
 
 	/* Mapper 176 */
 	{ 0xffde0de5,  176, DEFAULT, DEFAULT, 1, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* 梦幻之星4[简体](修正)一战一级.nes */

--- a/src/ines-correct.h
+++ b/src/ines-correct.h
@@ -368,6 +368,7 @@
 	/* Mapper 163: Nanjing, running with $5300=$04 */
 	{ 0xC9ABA7F0,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* Chrono Trigger - 时空之轮 */
 	{ 0x143B4D30,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* Final Fantasy VII - 最终幻想 7 */
+	{ 0x609458B6,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* Final Fantasy VII - 最终幻想 7, English translation */
 	{ 0x3CC55A44,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* The Legend of Zelda - 塞尔达传说: 神奇的帽子 */
 	{ 0x4752BD5E,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 七國大戰 */
 	{ 0x1121C0D1,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 三国志 之 傲视天地 */

--- a/src/ines-correct.h
+++ b/src/ines-correct.h
@@ -781,7 +781,7 @@
 	{ 0x42161530,  176,       2, DEFAULT, 1,    0x90,    0x07,   DENDY, NOEXTRA }, /* 龙魂 [protection removed].nes */
 	{ 0x8F8FC9A7,  176,       2, DEFAULT, 1,    0x90,    0x07,   DENDY, NOEXTRA }, /* 龙魂.nes */
 	{ 0xB6984DAD,  176,       3, DEFAULT, 1,    0x07,    0x0B, DEFAULT, NOEXTRA }, /* Super Mario 160-in-1 Funny Time.nes */
-	{ 0xB6984DAD,  176,       4, DEFAULT, 1,    0x07,    0x07, DEFAULT, NOEXTRA }, /* GameStar Smart Genius Deluxe.nes */
+	{ 0xAD82BBEA,  176,       4, DEFAULT, 1,    0x07,    0x07, DEFAULT, NOEXTRA }, /* GameStar Smart Genius Deluxe.nes */
 
 	/* Nanjing games that are sometimes found erroneously set to mapper 163 even though they use other mappers */
 	{ 0x3CD15707,  178,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* [NJ027] Fang Shi Yu (C) */

--- a/src/ines-correct.h
+++ b/src/ines-correct.h
@@ -783,6 +783,13 @@
 	{ 0xB6984DAD,  176,       3, DEFAULT, 1,    0x07,    0x0B, DEFAULT, NOEXTRA }, /* Super Mario 160-in-1 Funny Time.nes */
 	{ 0xB6984DAD,  176,       4, DEFAULT, 1,    0x07,    0x07, DEFAULT, NOEXTRA }, /* GameStar Smart Genius Deluxe.nes */
 
+	/* Nanjing games that are sometimes found erroneously set to mapper 163 even though they use other mappers */
+	{ 0x3CD15707,  178,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* [NJ027] Fang Shi Yu (C) */
+	{ 0x2779BB41,  534,       0,    MI_V, 0, DEFAULT,    0x07,   DENDY, NOEXTRA }, /* [NJ064] Shu Du (Sudoku) (C) */
+	{ 0x1DE558A1,  178,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* [NJ085] Shan Shan De Hong Xing (C) */
+	{ 0xF814EC57,  178,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* [NJ090] Yong Zhe Chuan Shuo (C) */
+	{ 0x53A1F436,  178,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* [NJ091] Xian Jian Wen Qing (C) */
+
 	/* Non-Mapper 176 files that are sometimes found erroneously set to mapper 176 */
 	{ 0x60AC647F,  260,       0, DEFAULT, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* (YH-4222) Super Game 4-in-1.nes */
 

--- a/src/ines-correct.h
+++ b/src/ines-correct.h
@@ -37,8 +37,6 @@
 
 	{ 0xaf5d7aa2,    0, DEFAULT,    MI_H, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* Clu Clu Land (W) [o3].nes */
 	{ 0xcfb224e6,  222, DEFAULT,    MI_H, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* Dragon Ninja (J) (PRG0) [p1][!].nes */
-	{ 0x82f204ae,  162, DEFAULT,    MI_H, 0,    0x70,    0x07, DEFAULT, NOEXTRA }, /* Liang Shan Ying Xiong (NJ023) (Ch) [!].nes */
-	{ 0x8589652D,  162, DEFAULT,    MI_H, 0,    0x70,    0x07, DEFAULT, NOEXTRA }, /* 农场小精灵.nes */
 	{ 0xad9c63e2,   70, DEFAULT,    MI_V, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* Space Shadow (Japan).nes */
 	{ 0xe1526228,  206, DEFAULT,    MI_V, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* Ki no Bouken - The Quest of Ki (Japan).nes */
 	{ 0xaf5d7aa2,    0, DEFAULT,    MI_H, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* Clu Clu Land (W) [o3].nes */
@@ -355,7 +353,131 @@
 	{ 0xb7f28915,  159, DEFAULT, DEFAULT, 1,    0x10, DEFAULT, DEFAULT, NOEXTRA }, /* Magical Taruruuto-kun 2 - Mahou Daibouken (Japan).nes */
 	{ 0x183859d2,  159, DEFAULT, DEFAULT, 1,    0x10, DEFAULT, DEFAULT, NOEXTRA }, /* Dragon Ball Z - Kyoushuu! Saiya Jin (Japan).nes */
 	{ 0x58152b42,  160, DEFAULT,    MI_V, 0, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* Pipe V (Asia) (Ja) (Unl).nes */
-	{ 0x1c098942,  162, DEFAULT, DEFAULT, 1, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* Xi You Ji Hou Zhuan (Ch).nes */
+
+	/* Mapper 162: Waixing FS304 */
+	{ 0x08FBF3F0,  162,       0,    MI_H, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* Mummy - 神鬼传奇 */
+	{ 0xF5D34C8E,  162,       0,    MI_H, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* Zelda 传说: 三神之力 */
+	{ 0xEE3A1CA8,  162,       0,    MI_H, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 法老王 - Pharaoh */
+	{ 0xCF4ADAAD,  162,       0,    MI_H, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 火焰纹章 - 圣战的系谱 */
+	{ 0xB2045E9C,  162,       0,    MI_H, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 聖火徽章 III */
+	{ 0x1C098942,  162,       0,    MI_H, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 西游记后传 */
+	/* Mapper 162: Nanjing games that use an FS304 feature as a protection check */
+	{ 0x8589652D,  162,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 农场小精灵 */
+	{ 0x82F204AE,  162,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 梁山英雄 */
+	
+	/* Mapper 163: Nanjing, running with $5300=$04 */
+	{ 0xC9ABA7F0,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* Chrono Trigger - 时空之轮 */
+	{ 0x143B4D30,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* Final Fantasy VII - 最终幻想 7 */
+	{ 0x3CC55A44,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* The Legend of Zelda - 塞尔达传说: 神奇的帽子 */
+	{ 0x4752BD5E,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 七國大戰 */
+	{ 0x1121C0D1,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 三国志 之 傲视天地 */
+	{ 0x8E4294A9,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 三国志: 曹操传 */
+	{ 0xF52468E7,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 三国无双: 猛将传 */
+	{ 0xEF7BA485,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 仙剑奇侠 */
+	{ 0x20E1CF44,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 仙界精灵 */
+	{ 0x9688AEEA,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 倚天传说 */
+	{ 0x04DFE0D4,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 倚天剑传奇 */
+	{ 0x6CB6D619,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 口袋宝石 - 银 */
+	{ 0x8C73A47B,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 哪吒传奇 */
+	{ 0xE40DA18F,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 圣剑传说 */
+	{ 0xC07CD2CE,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 圣斗士星矢: 天马之幻想 */
+	{ 0x9237C200,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 大话西游 */
+	{ 0x4FB02A43,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 天龙八部 */
+	{ 0x52D7FE18,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 太空幻想 */
+	{ 0xA01CA587,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 幻世录 */
+	{ 0x89F4ACD1,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 幻想传说 */
+	{ 0x65C63CC3,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 数码战队 2 */
+	{ 0x2C01DE06,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 数码暴龙 */
+	{ 0xB614AAA2,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 暗黑破坏神 - Diablo */
+	{ 0x80A18CDC,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 机器人大战 */
+	{ 0x33DB45BA,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 核心危机 */
+	{ 0x1B74A022,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 梦幻沙漏 */
+	{ 0x695A7A70,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 楚汉风云 */
+	{ 0xD0807FD2,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 水浒 III */
+	{ 0x524AF6E8,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 水浒神兽 (南晶) */
+	{ 0x2802E40F,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 汉刘邦 */
+	{ 0xAC491507,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 游戏王 */
+	{ 0x31C1BF98,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 牧场物语 */
+	{ 0x191F7D5E,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 真 Samurai Spirits - 武士道列传: 侍魂 */
+	{ 0x1FE67BB3,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 真 Samurai Spirits - 魂之利刃 */
+	{ 0x4973B16B,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 石器时代 */
+	{ 0x09C7AED3,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 葫芦金刚 */
+	{ 0x4E3EDF88,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 超级机器人大战 A */
+	{ 0x74C1EDC7,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 轩辕剑外传 之 天之痕 */
+	{ 0x723C6345,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 金庸群侠传: 书剑江山 */
+	{ 0xDA47B05A,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 隋唐英雄 */
+	{ 0x056F2B8E,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 雷电皇: Pikachu传说 */
+	{ 0x04166E96,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 魔幻世界 */
+	{ 0x85FA53E1,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 魔界塔士 */
+	{ 0x2121DAB2,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 魔界霸主 */
+	{ 0xE3EF9739,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 黄金太阳 */	
+	/* Mapper 163: Nanjing, running with $5300=$07 */
+	{ 0x6F94C5E5,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* Final Fantasy IV - 最终幻想 4: 光与暗 水晶纷争 */
+	{ 0xD6CBB05D,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* Naruto RPG - 火影忍者 */
+	{ 0xD7A4CBA5,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 七龙珠大冒险 - Dragon Ball */
+	{ 0xDF27B96C,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 三国大乱斗: 战国 - Orochi */
+	{ 0x8C60CECF,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 三国志: 吕布传 */
+	{ 0x44AC9C8E,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 三国群侠传 */
+	{ 0xA3193C51,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 倚天屠龙记 */
+	{ 0x98266D3A,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 傲视三国志 */
+	{ 0xA026AE52,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 口袋宝石 - 红 */
+	{ 0xB6F72A18,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 口袋宝石 - 蓝 */
+	{ 0x5108AB7F,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 口袋宝石 - 金 */
+	{ 0x8EB1B4CF,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 口袋水晶 */
+	{ 0xA66756AD,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 口袋钻石 */
+	{ 0x3A613060,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 吞食天地 VI: 刘备传 */
+	{ 0xB35BE92F,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 圣斗士星矢: 北欧突击篇 */
+	{ 0x15E50ECD,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 宠物高达战记 */
+	{ 0xBBAB3A61,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 拳皇R-1: 最强格斗王 */
+	{ 0x2DA3A49C,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 时空斗士 - Pegasus Senya */
+	{ 0x222A136A,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 武侠天地 */
+	{ 0xEBC6E2E2,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 毁灭之神 */
+	{ 0xE08AB52E,  163,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 魔兽世界: 恶魔猎人 */
+	/* Mapper 162: Nanjing, running with $5300=$07, but dumped without taking the D0/D1 bit swap into account.
+	               Such dumps need not be invalidated however, as they can run as mapper 162 when properly emulated. */
+	{ 0x9D8AA034,  162,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* Final Fantasy IV - 最终幻想4: 光与暗 水晶纷争 */
+	{ 0x5E66E6C4,  162,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* Naruto RPG - 火影忍者 */
+	{ 0x9DE10A91,  162,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 七龙珠大冒险 - Dragon Ball */
+	{ 0xFC209609,  162,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 三国大乱斗: 战国 - Orochi */
+	{ 0x696D98E3,  162,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 三国志: 吕布传 */
+	{ 0x9F197F2B,  162,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 三国群侠传 */
+	{ 0x975F64E2,  162,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 倚天屠龙记 */
+	{ 0x915C5179,  162,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 傲视三国志 */
+	{ 0x852BDB36,  162,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 口袋宝石 - 红 */
+	{ 0xB41CF445,  162,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 口袋宝石 - 蓝 */
+	{ 0x7829C3A9,  162,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 口袋宝石 - 金 */
+	{ 0xBC383C09,  162,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 口袋水晶 */
+	{ 0xA9C4712A,  162,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 口袋钻石 */
+	{ 0xC2B02B71,  162,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 吞食天地 VI: 刘备传 */
+	{ 0x054444A0,  162,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 圣斗士星矢: 北欧突击篇 */
+	{ 0x9BA518BA,  162,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 宠物高达战记 */
+	{ 0x4CE082F8,  162,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 拳皇R-1: 最强格斗王 */
+	{ 0x99FE9AB5,  162,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 时空斗士 - Pegasus Senya */
+	{ 0x57414FB6,  162,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 武侠天地 */
+	{ 0x979239DE,  162,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 毁灭之神 */
+	{ 0xEFF96E8A,  162,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 魔兽世界: 恶魔猎人 */
+	
+	/* Mapper 164: Dongda PEC-9588 and Yancheng cy2000-3 PCB */
+	{ 0xFE31765B,  164,       0,    MI_V, 0,    0x07,    0x07,   DENDY, NOEXTRA }, /* Pyramid 金字塔 PEC-9588 家庭电脑 */
+	{ 0x0878A7EE,  164,       0,    MI_H, 1,    0x35,    0x07,   DENDY, NOEXTRA }, /* Dark Seed - 黑暗之蛊 */
+	{ 0x56A0D271,  164,       0,    MI_H, 1,    0x35,    0x07,   DENDY, NOEXTRA }, /* Final Fantasy 太空戰士 V (rev0) */
+	{ 0xCB1EF911,  164,       0,    MI_H, 1,    0x35,    0x07,   DENDY, NOEXTRA }, /* Final Fantasy 太空戰士 V (rev1) */
+	{ 0x8209BA79,  164,       0,    MI_H, 1,    0x35,    0x07,   DENDY, NOEXTRA }, /* 櫻桃小丸子 */
+	{ 0xBC7562A6,  164,       0,    MI_H, 1,    0x35,    0x07,   DENDY, NOEXTRA }, /* 口袋精靈: 金 */
+	{ 0x65F1DB91,  164,       0,    MI_H, 1,    0x35,    0x07,   DENDY, NOEXTRA }, /* 大話西游 [restored, no good dump known] */
+	{ 0x0A244228,  164,       0,    MI_H, 1,    0x35,    0x07,   DENDY, NOEXTRA }, /* 岳飛傳 [restored, no good dump known] */
+
+	/* Mapper 558: Waixing FS??? and Yancheng YC-03-09 PCB */
+	{ 0xE65A8C08,  558,       0,    MI_H, 1,    0x30,    0x07,   DENDY, NOEXTRA }, /* 大話三國 */
+	{ 0x228559A7,  558,       0,    MI_H, 1,    0x30,    0x07,   DENDY, NOEXTRA }, /* 口袋精靈: 水晶 */
+	{ 0x8B41D49C,  558,       0,    MI_H, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* Pet Evolve - 宠物进化史 */
+	{ 0x5622EC51,  558,       0,    MI_V, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 三国志 II 代 */
+	{ 0xE7AEB114,  558,       0,    MI_H, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 口袋妖怪: 鑽石版 */
+	{ 0x8EB4BB51,  558,       0,    MI_H, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 口袋精靈: 紅 */
+	{ 0x48244391,  558,       0,    MI_H, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 宠物: 红 */
+	{ 0x01A24301,  558,       0,    MI_H, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 数码宝贝 */
+	{ 0x88CB68A7,  558,       0,    MI_H, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 数码暴龙 4: 水晶版 */
+	{ 0x081CAAFF,  558,       0,    MI_H, 1,    0x70,    0x07,   DENDY, NOEXTRA }, /* 盟军敢死队 - Commandos */
 
 	/* Mapper 176 */
 	{ 0xffde0de5,  176, DEFAULT, DEFAULT, 1, DEFAULT, DEFAULT, DEFAULT, NOEXTRA }, /* 梦幻之星4[简体](修正)一战一级.nes */

--- a/src/ines.c
+++ b/src/ines.c
@@ -577,7 +577,7 @@ INES_BOARD_BEGIN()
 	INES_BOARD( "BANDAI 24C01",             159, Mapper159_Init         ) /* Different type of EEPROM on the  bandai board */
 	INES_BOARD( "SA009",                    160, SA009_Init             )
 /*    INES_BOARD( "",                            161, Mapper161_Init ) */
-	INES_BOARD( "",                         162, UNLFS304_Init          )
+	INES_BOARD( "",                         162, Mapper162_Init         )
 	INES_BOARD( "",                         163, Mapper163_Init         )
 	INES_BOARD( "",                         164, Mapper164_Init         )
 	INES_BOARD( "",                         165, Mapper165_Init         )
@@ -802,6 +802,7 @@ INES_BOARD_BEGIN()
 	INES_BOARD( "T-230",                    529, UNLT230_Init           )
 	INES_BOARD( "AX5705",                   530, UNLAX5705_Init         )
 	INES_BOARD( "LH53",                     535, LH53_Init              )
+	INES_BOARD( "YC-03-09",                 558, Mapper558_Init         )
 INES_BOARD_END()
 
 static uint32 get_ines_version(void) {

--- a/src/ines.h
+++ b/src/ines.h
@@ -165,6 +165,7 @@ void Mapper156_Init(CartInfo *);
 void Mapper157_Init(CartInfo *);
 void Mapper158_Init(CartInfo *);
 void Mapper159_Init(CartInfo *);
+void Mapper162_Init(CartInfo *);
 void Mapper163_Init(CartInfo *);
 void Mapper164_Init(CartInfo *);
 void Mapper165_Init(CartInfo *);
@@ -295,5 +296,6 @@ void Mapper541_Init(CartInfo *);
 void Mapper543_Init(CartInfo *);
 void Mapper550_Init(CartInfo *);
 void Mapper554_Init(CartInfo *);
+void Mapper558_Init(CartInfo *);
 
 #endif

--- a/src/unif.c
+++ b/src/unif.c
@@ -462,7 +462,7 @@ static BMAPPING bmap[] = {
 	{ "EWROM",                        5, EWROM_Init,            0 },
 	{ "FK23C",                      176, BMCFK23C_Init,         BMCFLAG_256KCHRR },
 	{ "FK23CA",                     176, BMCFK23CA_Init,        BMCFLAG_256KCHRR },
-	{ "FS304",                      162, UNLFS304_Init,         0 },
+	{ "FS304",                      162, Mapper162_Init,        0 },
 	{ "G-146",                      349, BMCG146_Init,          0 },
 	{ "GK-192",                 NO_INES, BMCGK192_Init,         0 }, /* mapper 58? */
 	{ "GS-2004",                    283, BMCGS2004_Init,        0 },

--- a/src/unif.h
+++ b/src/unif.h
@@ -118,7 +118,6 @@ void UNLCC21_Init(CartInfo *info);
 void UNLCITYFIGHT_Init(CartInfo *info);
 void UNLD2000_Init(CartInfo *info);
 void UNLEDU2000_Init(CartInfo *info);
-void UNLFS304_Init(CartInfo *info);
 void UNLH2288_Init(CartInfo *info);
 void UNLKOF97_Init(CartInfo *info);
 void UNLKS7012_Init(CartInfo *info);


### PR DESCRIPTION
Rewrite the emulation of mappers 162, 163, 164 and add the emulation of mapper 558 to incorporate Krzysiobal's findings from analysing real hardware. Add EEPROM saving to mappers 164 and 558. Update the database in ines-correct.h to make sure that all current dumps still work while adding redumps.

Emulation of mapper 163 is not complete; at least one Nanjing game has a PCM chip that is not emulated yet because no good ROM image of that game, with the PCM chip writes intact, is available.