### PR TITLE
Fix core options version detection

### DIFF
--- a/src/drivers/libretro/libretro_core_options.h
+++ b/src/drivers/libretro/libretro_core_options.h
@@ -477,7 +477,7 @@ static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
    if (!environ_cb)
       return;
 
-   if (environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version) && (version == 1))
+   if (environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version) && (version >= 1))
    {
       struct retro_core_options_intl core_options_intl;
       unsigned language = 0;


### PR DESCRIPTION
At present the core falls back to core options v0 (no sublabels, etc.) when using recent versions of RetroArch due an error in the 'supported core options version' check in `libretro_core_options.h`. This trivial PR fixes the issue.