### PR TITLE
Add support for emulated Game Genie add-on

### DIFF
--- a/src/cart.c
+++ b/src/cart.c
@@ -23,6 +23,7 @@
 #include <stdio.h>
 
 #include <string/stdstring.h>
+#include <file/file_path.h>
 #include <streams/file_stream.h>
 
 #include "fceu-types.h"
@@ -353,20 +354,25 @@ void FCEU_OpenGenie(void) {
 
 		fn = FCEU_MakeFName(FCEUMKF_GGROM, 0, 0);
 
-		if (!string_is_empty(fn))
+		if (!string_is_empty(fn) && path_is_valid(fn))
 			fp = filestream_open(fn,
 					RETRO_VFS_FILE_ACCESS_READ,
 					RETRO_VFS_FILE_ACCESS_HINT_NONE);
 
+		free(fn);
+		fn = NULL;
+
 		if (!fp) {
-			FCEU_PrintError("Error opening Game Genie ROM image!");
+			FCEU_PrintError("Error opening Game Genie ROM image!\n");
+			FCEUD_DispMessage(RETRO_LOG_WARN, 3000, "Game Genie ROM image (gamegenie.nes) missing");
 			free(GENIEROM);
 			GENIEROM = 0;
 			return;
 		}
 		if (filestream_read(fp, GENIEROM, 16) != 16) {
  grerr:
-			FCEU_PrintError("Error reading from Game Genie ROM image!");
+			FCEU_PrintError("Error reading from Game Genie ROM image!\n");
+			FCEUD_DispMessage(RETRO_LOG_WARN, 3000, "Failed to read Game Genie ROM image (gamegenie.nes)");
 			free(GENIEROM);
 			GENIEROM = 0;
 			filestream_close(fp);

--- a/src/cheat.c
+++ b/src/cheat.c
@@ -114,7 +114,6 @@ void RebuildSubCheats(void) {
 		if (c->type == 1 && c->status) {
 			if (GetReadHandler(c->addr) == SubCheatsRead) {
 				/* Prevent a catastrophe by this check. */
-				/* FCEU_DispMessage("oops"); */
 			} else {
 				SubCheats[numsubcheats].PrevRead = GetReadHandler(c->addr);
 				SubCheats[numsubcheats].addr = c->addr;

--- a/src/driver.h
+++ b/src/driver.h
@@ -2,6 +2,7 @@
 #define _FCEU_DRIVER_H
 
 #include <stdio.h>
+#include <libretro.h>
 
 #ifdef  __cplusplus
 extern "C" {
@@ -37,7 +38,9 @@ void FCEUD_SetPalette(uint8 index, uint8 r, uint8 g, uint8 b);
 /* Displays an error.  Can block or not. */
 void FCEUD_PrintError(char *s);
 void FCEUD_Message(char *s);
-void FCEUD_DispMessage(char *m);
+
+void FCEUD_DispMessage(enum retro_log_level level, unsigned duration, char *str);
+void FCEU_DispMessage(enum retro_log_level level, unsigned duration, char *format, ...);
 
 int FCEUI_BeginWaveRecord(char *fn);
 int FCEUI_EndWaveRecord(void);
@@ -99,7 +102,14 @@ void FCEUI_DisableSpriteLimitation(int a);
 /* -1 = no change, 0 = show, 1 = hide, 2 = internal toggle */
 void FCEUI_SetRenderDisable(int sprites, int bg);
 
-FCEUGI *FCEUI_LoadGame(const char *name, const uint8_t *buf, size_t bufsize);
+/* frontend_post_load_init_cb() is called immediately
+ * after loading the ROM, allowing any frontend
+ * initialisation that is dependent on ROM type to
+ * be performed before the regular internal post-load
+ * initialisation */
+typedef void (*frontend_post_load_init_cb_t)(void);
+FCEUGI *FCEUI_LoadGame(const char *name, const uint8_t *databuf, size_t databufsize,
+      frontend_post_load_init_cb_t frontend_post_load_init_cb);
 
 #ifdef COPYFAMI
 /* Fake UNIF board to start new CFHI instance */
@@ -168,8 +178,6 @@ void FCEUI_LoadMovie(char *fname);
 
 int32 FCEUI_GetDesiredFPS(void);
 void FCEUI_SaveSnapshot(void);
-void FCEU_DispMessage(char *format, ...);
-#define FCEUI_DispMessage FCEU_DispMessage
 
 int FCEUI_DecodePAR(const char *code, uint16 *a, uint8 *v, int *c, int *type);
 int FCEUI_DecodeGG(const char *str, uint16 *a, uint8 *v, int *c);

--- a/src/drivers/libretro/libretro_core_options.h
+++ b/src/drivers/libretro/libretro_core_options.h
@@ -17,7 +17,7 @@ extern "C" {
  ********************************
 */
 
-#define MAX_CORE_OPTIONS 34
+#define MAX_CORE_OPTIONS 35
 
 /* RETRO_LANGUAGE_ENGLISH */
 
@@ -29,6 +29,11 @@ extern "C" {
  *   frontend language definition */
 
 struct retro_core_option_v2_category option_cats_us[] = {
+   {
+      "system",
+      "System",
+      "Configure region / hardware add-on parameters."
+   },
    {
       "video",
       "Video",
@@ -68,15 +73,29 @@ struct retro_core_option_v2_definition option_defs_us_common[] = {
       NULL,
       "Force core to use NTSC, PAL or Dendy region timings.",
       NULL,
-      NULL,
+      "system",
       {
          { "Auto",  NULL },
          { "NTSC",  NULL },
          { "PAL",   NULL },
          { "Dendy", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "Auto",
+   },
+   {
+      "fceumm_game_genie",
+      "Game Genie Add-On (Restart)",
+      NULL,
+      "Enable emulation of a Game Genie add-on cartridge, allowing cheat codes to be entered when launching games. The Game Genie ROM file 'gamegenie.nes' must be present in the frontend's system directory. Does not apply to FDS or arcade content.",
+      NULL,
+      "system",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled",
    },
    {
       "fceumm_show_adv_system_options",
@@ -117,7 +136,7 @@ struct retro_core_option_v2_definition option_defs_us_common[] = {
          { "8:7 PAR", NULL },
          { "4:3",     NULL },
          { "PP",      "Pixel Perfect" },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "8:7 PAR",
    },
@@ -132,7 +151,7 @@ struct retro_core_option_v2_definition option_defs_us_common[] = {
       {
          { "enabled",  NULL },
          { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "enabled",
    },
@@ -147,7 +166,7 @@ struct retro_core_option_v2_definition option_defs_us_common[] = {
       {
          { "disabled", NULL },
          { "enabled",  NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "disabled",
    },
@@ -161,7 +180,7 @@ struct retro_core_option_v2_definition option_defs_us_common[] = {
       {
          { "disabled", NULL },
          { "enabled",  NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "enabled",
    },
@@ -193,7 +212,7 @@ struct retro_core_option_v2_definition option_defs_us_common[] = {
          { "wavebeam",             "nakedarthur's Wavebeam" },
          { "raw",                  "Raw" },
          { "custom",               "Custom" },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "default",
    },
@@ -227,7 +246,7 @@ struct retro_core_option_v2_definition option_defs_us_common[] = {
          { "Low",       NULL },
          { "High",      NULL },
          { "Very High", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "Low",
    },
@@ -241,7 +260,7 @@ struct retro_core_option_v2_definition option_defs_us_common[] = {
       {
          { "disabled", NULL },
          { "enabled",  NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "disabled",
    },
@@ -264,7 +283,7 @@ struct retro_core_option_v2_definition option_defs_us_common[] = {
          { "8",  "80%" },
          { "9",  "90%" },
          { "10", "100%" },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "7",
    },
@@ -278,7 +297,7 @@ struct retro_core_option_v2_definition option_defs_us_common[] = {
       {
          { "enabled",  NULL },
          { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "enabled",
    },
@@ -292,7 +311,7 @@ struct retro_core_option_v2_definition option_defs_us_common[] = {
       {
          { "enabled",  NULL },
          { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "enabled",
    },
@@ -306,7 +325,7 @@ struct retro_core_option_v2_definition option_defs_us_common[] = {
       {
          { "enabled",  NULL },
          { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "enabled",
    },
@@ -320,7 +339,7 @@ struct retro_core_option_v2_definition option_defs_us_common[] = {
       {
          { "enabled",  NULL },
          { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "enabled",
    },
@@ -334,7 +353,7 @@ struct retro_core_option_v2_definition option_defs_us_common[] = {
       {
          { "enabled",  NULL },
          { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "enabled",
    },
@@ -350,7 +369,7 @@ struct retro_core_option_v2_definition option_defs_us_common[] = {
          { "Player 1", NULL },
          { "Player 2", NULL },
          { "Both",     NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "None",
    },
@@ -370,7 +389,7 @@ struct retro_core_option_v2_definition option_defs_us_common[] = {
          { "15", NULL },
          { "30", NULL },
          { "60", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "3",
    },
@@ -385,7 +404,7 @@ struct retro_core_option_v2_definition option_defs_us_common[] = {
          { "lightgun",    "Lightgun" },
          { "touchscreen", "Touchscreen" },
          { "mouse",       "Mouse" },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "lightgun",
    },
@@ -399,7 +418,7 @@ struct retro_core_option_v2_definition option_defs_us_common[] = {
       {
          { "enabled",  NULL },
          { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "enabled",
    },
@@ -446,7 +465,7 @@ struct retro_core_option_v2_definition option_defs_us_common[] = {
       {
          { "disabled", NULL },
          { "enabled",  NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "disabled",
    },
@@ -460,7 +479,7 @@ struct retro_core_option_v2_definition option_defs_us_common[] = {
       {
          { "disabled", NULL },
          { "enabled",  NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "disabled",
    },
@@ -475,7 +494,7 @@ struct retro_core_option_v2_definition option_defs_us_common[] = {
          { "disabled",      NULL },
          { "2x-Postrender", NULL },
          { "2x-VBlank",     NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "disabled",
    },
@@ -490,7 +509,7 @@ struct retro_core_option_v2_definition option_defs_us_common[] = {
          { "fill $ff", "$FF" },
          { "fill $00", "$00" },
          { "random",   "Random" },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "fill $ff",
    },

--- a/src/fceu.h
+++ b/src/fceu.h
@@ -107,7 +107,6 @@ extern FCEUS FSettings;
 
 void FCEU_PrintError(char *format, ...);
 void FCEU_printf(char *format, ...);
-void FCEU_DispMessage(char *format, ...);
 
 void SetNESDeemph(uint8 d, int force);
 void DrawTextTrans(uint8 *dest, uint32 width, uint8 *textmsg, uint8 fgcolor);

--- a/src/fds.c
+++ b/src/fds.c
@@ -179,12 +179,12 @@ static void FDSInit(void) {
 
 void FCEU_FDSInsert(int oride) {
 	if (InDisk == 255) {
-		FCEU_DispMessage("Disk %d of %d Side %s Inserted",
-			1 + (SelectDisk >> 1), (TotalSides + 1) >> 1, (SelectDisk & 1) ? "B" : "A");
+		FCEU_DispMessage(RETRO_LOG_INFO, 2000, "Disk %d of %d Side %s Inserted",
+				1 + (SelectDisk >> 1), (TotalSides + 1) >> 1, (SelectDisk & 1) ? "B" : "A");
 		InDisk = SelectDisk;
 	} else {
-		FCEU_DispMessage("Disk %d of %d Side %s Ejected",
-			1 + (SelectDisk >> 1), (TotalSides + 1) >> 1, (SelectDisk & 1) ? "B" : "A");
+		FCEU_DispMessage(RETRO_LOG_INFO, 2000, "Disk %d of %d Side %s Ejected",
+				1 + (SelectDisk >> 1), (TotalSides + 1) >> 1, (SelectDisk & 1) ? "B" : "A");
 		InDisk = 255;
 	}
 }
@@ -195,12 +195,12 @@ void FCEU_FDSEject(void) {
 
 void FCEU_FDSSelect(void) {
 	if (InDisk != 255) {
-		FCEU_DispMessage("Eject disk before selecting.");
+		FCEUD_DispMessage(RETRO_LOG_WARN, 2000, "Eject disk before selecting");
 		return;
 	}
 	SelectDisk = ((SelectDisk + 1) % TotalSides) & 3;
-	FCEU_DispMessage("Disk %d of %d Side %s Selected",
-		1 + (SelectDisk >> 1), (TotalSides + 1) >> 1, (SelectDisk & 1) ? "B" : "A");
+	FCEU_DispMessage(RETRO_LOG_INFO, 2000, "Disk %d of %d Side %s Selected",
+			1 + (SelectDisk >> 1), (TotalSides + 1) >> 1, (SelectDisk & 1) ? "B" : "A");
 }
 
 /* 2018/12/15 - update irq timings */
@@ -710,6 +710,7 @@ int FDSLoad(const char *name, FCEUFILE *fp) {
 
 	if (!(zp = FCEU_fopen(fn, NULL, 0))) {
 		FCEU_PrintError("FDS BIOS ROM image missing!\n");
+		FCEUD_DispMessage(RETRO_LOG_ERROR, 3000, "FDS BIOS image (disksys.rom) missing");
 		free(fn);
 		return 0;
 	}
@@ -730,6 +731,7 @@ int FDSLoad(const char *name, FCEUFILE *fp) {
 		FDSBIOS = NULL;
 		FCEU_fclose(zp);
 		FCEU_PrintError("Error reading FDS BIOS ROM image.\n");
+		FCEUD_DispMessage(RETRO_LOG_ERROR, 3000, "Error reading FDS BIOS image (disksys.rom)");
 		return 0;
 	}
 

--- a/src/file.c
+++ b/src/file.c
@@ -28,6 +28,7 @@
 #endif
 
 #include <string/stdstring.h>
+#include <file/file_path.h>
 #include <streams/file_stream.h>
 
 #include "fceu-types.h"
@@ -88,7 +89,7 @@ FCEUFILE * FCEU_fopen(const char *path, const uint8 *buffer, size_t bufsize)
    {
       RFILE *t = NULL;
 
-      if (!string_is_empty(path))
+      if (!string_is_empty(path) && path_is_valid(path))
          t = filestream_open(path,
                RETRO_VFS_FILE_ACCESS_READ,
                RETRO_VFS_FILE_ACCESS_HINT_NONE);

--- a/src/general.c
+++ b/src/general.c
@@ -67,7 +67,7 @@ char *FCEU_MakeFName(int type, int id1, char *cd1)
    {
       case FCEUMKF_GGROM:
          fill_pathname_join(tmp, BaseDirectory,
-               "gg.rom", sizeof(tmp));
+               "gamegenie.nes", sizeof(tmp));
          break;
       case FCEUMKF_FDSROM:
          fill_pathname_join(tmp, BaseDirectory,

--- a/src/palette.c
+++ b/src/palette.c
@@ -23,6 +23,7 @@
 #include <math.h>
 
 #include <string/stdstring.h>
+#include <file/file_path.h>
 #include <streams/file_stream.h>
 
 #include "fceu-types.h"
@@ -197,7 +198,7 @@ void FCEU_LoadGamePalette(void) {
 
 	fn = FCEU_MakeFName(FCEUMKF_PALETTE, 0, 0);
 
-	if (!string_is_empty(fn))
+	if (!string_is_empty(fn) && path_is_valid(fn))
 		fp = filestream_open(fn,
 				RETRO_VFS_FILE_ACCESS_READ,
 				RETRO_VFS_FILE_ACCESS_HINT_NONE);

--- a/src/video.c
+++ b/src/video.c
@@ -86,16 +86,19 @@ void FCEU_PutImageDummy(void)
 {
 }
 
-void FCEU_DispMessage(char *format, ...)
+void FCEU_DispMessage(enum retro_log_level level, unsigned duration, char *format, ...)
 {
+   static char msg[512] = {0};
    va_list ap;
-   static char errmsg[65];
+
+   if (!format || (*format == '\0'))
+      return;
 
    va_start(ap, format);
-   vsprintf(errmsg, format, ap);
+   vsprintf(msg, format, ap);
    va_end(ap);
 
-   FCEUD_DispMessage(errmsg);
+   FCEUD_DispMessage(level, duration, msg);
 }
 
 void FCEU_ResetMessages(void)


### PR DESCRIPTION
FCEUmm has long supported emulation of the Game Genie cartridge add-on, but this is currently unavailable in the libretro core. This PR wires up said functionality:

- A new core option `Game Genie Add-On (Restart)` has been added (disabled by default)
- In order for the option to apply, the Game Genie ROM file named `gamegenie.nes` must be present in the frontend system directory
- Game Genie support is disabled for FDS and arcade content
- Save states do not function (and are disabled) while the Game Genie boot screen is open

After enabling `Game Genie Add-On (Restart)`, launching a game will cause the Game Genie boot screen to appear. Codes can be entered with the gamepad (as on real hardware): D-Pad to move, A to select, B to delete. For example:
```
Super Mario Bros.
YSAOPE + YEAOZA + YEAPYA        Start on World 8
```

![Screenshot_2021-10-21_12-31-09](https://user-images.githubusercontent.com/38211560/138304680-7e433cfb-520f-47c3-8df4-26b62700b704.png)

Press RetroPad Start and the game will load with the cheat applied:

![Screenshot_2021-10-21_12-31-19](https://user-images.githubusercontent.com/38211560/138305204-026b2a3d-87ac-4ac4-8d3f-23261a579add.png)

![Screenshot_2021-10-21_12-31-31](https://user-images.githubusercontent.com/38211560/138305219-38c0334d-4d17-4b37-900f-881f30d2dc84.png)

Why would we want this functionality, when the regular cheat interface is already available? Because:

- It provides an authentic experience
- It enables cheats when using frontends that don't support the regular cheat interface
- All the code was already in place, and it was easy to enable :)

In addition, during the process of implementing this, the core's OSD messaging code was overhauled and cleaned up. OSD warnings will be displayed when appropriate if the Game Genie ROM file is missing, and also if the FDS bios is missing. OSD message durations have been shortened a little, and the core makes use of the extended messaging interface when available.


