### PR TITLE
Enable switching of colour palettes via RetroPad L2 + D-Pad Left/Right

### DIFF
--- a/src/driver.h
+++ b/src/driver.h
@@ -39,8 +39,8 @@ void FCEUD_SetPalette(uint8 index, uint8 r, uint8 g, uint8 b);
 void FCEUD_PrintError(char *s);
 void FCEUD_Message(char *s);
 
-void FCEUD_DispMessage(enum retro_log_level level, unsigned duration, char *str);
-void FCEU_DispMessage(enum retro_log_level level, unsigned duration, char *format, ...);
+void FCEUD_DispMessage(enum retro_log_level level, unsigned duration, const char *str);
+void FCEU_DispMessage(enum retro_log_level level, unsigned duration, const char *format, ...);
 
 int FCEUI_BeginWaveRecord(char *fn);
 int FCEUI_EndWaveRecord(void);

--- a/src/video.c
+++ b/src/video.c
@@ -86,7 +86,7 @@ void FCEU_PutImageDummy(void)
 {
 }
 
-void FCEU_DispMessage(enum retro_log_level level, unsigned duration, char *format, ...)
+void FCEU_DispMessage(enum retro_log_level level, unsigned duration, const char *format, ...)
 {
    static char msg[512] = {0};
    va_list ap;


### PR DESCRIPTION
At present is difficult to compare the core's `Color Palette` options because these can only be set via the quick menu. This PR adds the ability to switch to the next/previous colour palette by holding RetroPad L2 and pressing D-Pad Left/Right while content is running:

![screen_record__2021_10_22__13_27_45](https://user-images.githubusercontent.com/38211560/138454321-d0ae2c85-e05f-403b-b867-a88aa5c9d904.gif)

This functionality is only available when using frontends that support the new `RETRO_ENVIRONMENT_SET_VARIABLE` callback.

