### PR TITLE
Updates to mappers 256, 289, 344, 432.

### DIFF
--- a/src/boards/432.c
+++ b/src/boards/432.c
@@ -44,6 +44,7 @@ static DECLFR(M432Read) {
 
 static DECLFW(M432Write) {
 	EXPREGS[A & 1] = V;
+	if (~A &1 && ~V &1) EXPREGS[1] =0; /* Writing 0 to register 0 clears register 1 */
 	FixMMC3PRG(MMC3_cmd);
 	FixMMC3CHR(MMC3_cmd);
 }
@@ -51,7 +52,7 @@ static DECLFW(M432Write) {
 static void M432Reset(void) {
 	EXPREGS[0] = 0;
 	EXPREGS[1] = 0;
-	EXPREGS[2] = (EXPREGS[2] +1) & 3;
+	EXPREGS[2]++;
 	MMC3RegReset();
 }
 

--- a/src/boards/432.c
+++ b/src/boards/432.c
@@ -32,12 +32,12 @@ static void M432CW(uint32 A, uint8 V) {
 static void M432PW(uint32 A, uint8 V) {
 	int prgAND = (EXPREGS[1] & 0x02) ? 0x0F : 0x1F;
 	int prgOR  = ((EXPREGS[1] << 4) & 0x10) | (EXPREGS[1] << 1) & 0x20;
-	if ((A < 0xC000) || (~EXPREGS[1] & 0x40)) setprg8(A,          (V & prgAND) | (prgOR & ~prgAND));
-	if ((A < 0xC000) &&  (EXPREGS[1] & 0x40)) setprg8(A | 0x4000, (V & prgAND) | (prgOR & ~prgAND));
+	if ((A < 0xC000) || (~EXPREGS[1] & 0x40)) setprg8(A,          (V & prgAND) | (prgOR & ~prgAND) & (EXPREGS[1] & 0x80?~2:~0));
+	if ((A < 0xC000) &&  (EXPREGS[1] & 0x40)) setprg8(A | 0x4000, (V & prgAND) | (prgOR & ~prgAND) | (EXPREGS[1] & 0x80? 2: 0));
 }
 
 static DECLFR(M432Read) {
-   if (EXPREGS[0] & 1)
+   if (EXPREGS[0] & 1 || EXPREGS[1] & 0x20)
 	  return EXPREGS[2];
    return CartBR(A);
 }

--- a/src/boards/onebus.c
+++ b/src/boards/onebus.c
@@ -126,22 +126,22 @@ static void Sync(void) {
 }
 
 static const uint8 cpuMangle[16][4] = {
-	{ 0, 1, 2, 3 }, 	// Submapper 0: Normal
-	{ 0, 1, 2, 3 }, 	// Submapper 1: Waixing VT03
-	{ 1, 0, 2, 3 }, 	// Submapper 2: Trump Grand
-	{ 0, 1, 2, 3 }, 	// Submapper 3: Zechess
-	{ 0, 1, 2, 3 }, 	// Submapper 4: Qishenglong
-	{ 0, 1, 2, 3 }, 	// Submapper 5: Waixing VT02
-	{ 0, 1, 2, 3 }, 	// Submapper 6: unused so far
-	{ 0, 1, 2, 3 }, 	// Submapper 7: unused so far
-	{ 0, 1, 2, 3 }, 	// Submapper 8: unused so far
-	{ 0, 1, 2, 3 }, 	// Submapper 9: unused so far
-	{ 0, 1, 2, 3 }, 	// Submapper A: unused so far
-	{ 0, 1, 2, 3 }, 	// Submapper B: unused so far
-	{ 0, 1, 2, 3 }, 	// Submapper C: unused so far
-	{ 0, 1, 2, 3 }, 	// Submapper D: Cube Tech (CPU opcode encryption only)
-	{ 0, 1, 2, 3 }, 	// Submapper E: Karaoto (CPU opcode encryption only)
-	{ 0, 1, 2, 3 }  	// Submapper F: Jungletac (CPU opcode encryption only)
+	{ 0, 1, 2, 3 }, 	/* Submapper 0: Normal                                  */
+	{ 0, 1, 2, 3 }, 	/* Submapper 1: Waixing VT03                            */
+	{ 1, 0, 2, 3 }, 	/* Submapper 2: Trump Grand                             */
+	{ 0, 1, 2, 3 }, 	/* Submapper 3: Zechess                                 */
+	{ 0, 1, 2, 3 }, 	/* Submapper 4: Qishenglong                             */
+	{ 0, 1, 2, 3 }, 	/* Submapper 5: Waixing VT02                            */
+	{ 0, 1, 2, 3 }, 	/* Submapper 6: unused so far                           */
+	{ 0, 1, 2, 3 }, 	/* Submapper 7: unused so far                           */
+	{ 0, 1, 2, 3 }, 	/* Submapper 8: unused so far                           */
+	{ 0, 1, 2, 3 }, 	/* Submapper 9: unused so far                           */
+	{ 0, 1, 2, 3 }, 	/* Submapper A: unused so far                           */
+	{ 0, 1, 2, 3 }, 	/* Submapper B: unused so far                           */
+	{ 0, 1, 2, 3 }, 	/* Submapper C: unused so far                           */
+	{ 0, 1, 2, 3 }, 	/* Submapper D: Cube Tech (CPU opcode encryption only)  */
+	{ 0, 1, 2, 3 }, 	/* Submapper E: Karaoto (CPU opcode encryption only)    */
+	{ 0, 1, 2, 3 }  	/* Submapper F: Jungletac (CPU opcode encryption only)  */
 };
 static DECLFW(UNLOneBusWriteCPU410X) {
 /*	FCEU_printf("CPU %04x:%04x\n",A,V); */
@@ -159,22 +159,22 @@ static DECLFW(UNLOneBusWriteCPU410X) {
 }
 
 static const uint8 ppuMangle[16][6] = {
-	{ 0, 1, 2, 3, 4, 5 }, 	// Submapper 0: Normal
-	{ 1, 0, 5, 4, 3, 2 }, 	// Submapper 1: Waixing VT03
-	{ 0, 1, 2, 3, 4, 5 }, 	// Submapper 2: Trump Grand
-	{ 5, 4, 3, 2, 0, 1 }, 	// Submapper 3: Zechess
-	{ 2, 5, 0, 4, 3, 1 }, 	// Submapper 4: Qishenglong
-	{ 1, 0, 5, 4, 3, 2 }, 	// Submapper 5: Waixing VT02
-	{ 0, 1, 2, 3, 4, 5 }, 	// Submapper 6: unused so far
-	{ 0, 1, 2, 3, 4, 5 }, 	// Submapper 7: unused so far
-	{ 0, 1, 2, 3, 4, 5 }, 	// Submapper 8: unused so far
-	{ 0, 1, 2, 3, 4, 5 }, 	// Submapper 9: unused so far
-	{ 0, 1, 2, 3, 4, 5 }, 	// Submapper A: unused so far
-	{ 0, 1, 2, 3, 4, 5 }, 	// Submapper B: unused so far
-	{ 0, 1, 2, 3, 4, 5 }, 	// Submapper C: unused so far
-	{ 0, 1, 2, 3, 4, 5 }, 	// Submapper D: Cube Tech (CPU opcode encryption only)
-	{ 0, 1, 2, 3, 4, 5 }, 	// Submapper E: Karaoto (CPU opcode encryption only)
-	{ 0, 1, 2, 3, 4, 5 }  	// Submapper F: Jungletac (CPU opcode encryption only)
+	{ 0, 1, 2, 3, 4, 5 }, 	/* Submapper 0: Normal                                  */
+	{ 1, 0, 5, 4, 3, 2 }, 	/* Submapper 1: Waixing VT03                            */
+	{ 0, 1, 2, 3, 4, 5 }, 	/* Submapper 2: Trump Grand                             */
+	{ 5, 4, 3, 2, 0, 1 }, 	/* Submapper 3: Zechess                                 */
+	{ 2, 5, 0, 4, 3, 1 }, 	/* Submapper 4: Qishenglong                             */
+	{ 1, 0, 5, 4, 3, 2 }, 	/* Submapper 5: Waixing VT02                            */
+	{ 0, 1, 2, 3, 4, 5 }, 	/* Submapper 6: unused so far                           */
+	{ 0, 1, 2, 3, 4, 5 }, 	/* Submapper 7: unused so far                           */
+	{ 0, 1, 2, 3, 4, 5 }, 	/* Submapper 8: unused so far                           */
+	{ 0, 1, 2, 3, 4, 5 }, 	/* Submapper 9: unused so far                           */
+	{ 0, 1, 2, 3, 4, 5 }, 	/* Submapper A: unused so far                           */
+	{ 0, 1, 2, 3, 4, 5 }, 	/* Submapper B: unused so far                           */
+	{ 0, 1, 2, 3, 4, 5 }, 	/* Submapper C: unused so far                           */
+	{ 0, 1, 2, 3, 4, 5 }, 	/* Submapper D: Cube Tech (CPU opcode encryption only)  */
+	{ 0, 1, 2, 3, 4, 5 }, 	/* Submapper E: Karaoto (CPU opcode encryption only)    */
+	{ 0, 1, 2, 3, 4, 5 }  	/* Submapper F: Jungletac (CPU opcode encryption only)  */
 };
 static DECLFW(UNLOneBusWritePPU201X) {
 /*	FCEU_printf("PPU %04x:%04x\n",A,V); */
@@ -185,22 +185,22 @@ static DECLFW(UNLOneBusWritePPU201X) {
 }
 
 static const uint8 mmc3Mangle[16][8] = {
-	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	// Submapper 0: Normal
-	{ 5, 4, 3, 2, 1, 0, 6, 7 }, 	// Submapper 1: Waixing VT03
-	{ 0, 1, 2, 3, 4, 5, 7, 6 }, 	// Submapper 2: Trump Grand
-	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	// Submapper 3: Zechess
-	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	// Submapper 4: Qishenglong
-	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	// Submapper 5: Waixing VT02
-	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	// Submapper 6: unused so far
-	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	// Submapper 7: unused so far
-	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	// Submapper 8: unused so far
-	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	// Submapper 9: unused so far
-	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	// Submapper A: unused so far
-	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	// Submapper B: unused so far
-	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	// Submapper C: unused so far
-	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	// Submapper D: Cube Tech (CPU opcode encryption only)
-	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	// Submapper E: Karaoto (CPU opcode encryption only)
-	{ 0, 1, 2, 3, 4, 5, 6, 7 }  	// Submapper F: Jungletac (CPU opcode encryption only)
+	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	/* Submapper 0: Normal                                 */
+	{ 5, 4, 3, 2, 1, 0, 6, 7 }, 	/* Submapper 1: Waixing VT03                           */
+	{ 0, 1, 2, 3, 4, 5, 7, 6 }, 	/* Submapper 2: Trump Grand                            */
+	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	/* Submapper 3: Zechess                                */
+	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	/* Submapper 4: Qishenglong                            */
+	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	/* Submapper 5: Waixing VT02                           */
+	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	/* Submapper 6: unused so far                          */
+	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	/* Submapper 7: unused so far                          */
+	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	/* Submapper 8: unused so far                          */
+	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	/* Submapper 9: unused so far                          */
+	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	/* Submapper A: unused so far                          */
+	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	/* Submapper B: unused so far                          */
+	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	/* Submapper C: unused so far                          */
+	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	/* Submapper D: Cube Tech (CPU opcode encryption only) */
+	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	/* Submapper E: Karaoto (CPU opcode encryption only)   */
+	{ 0, 1, 2, 3, 4, 5, 6, 7 }  	/* Submapper F: Jungletac (CPU opcode encryption only) */
 };
 static DECLFW(UNLOneBusWriteMMC3) {
 /*	FCEU_printf("MMC %04x:%04x\n",A,V); */

--- a/src/boards/onebus.c
+++ b/src/boards/onebus.c
@@ -27,6 +27,8 @@
 
 #include "mapinc.h"
 
+static uint8 submapper;
+
 /* General Purpose Registers */
 static uint8 cpu410x[16], ppu201x[16], apu40xx[64];
 
@@ -35,9 +37,6 @@ static uint8 IRQCount, IRQa, IRQReload;
 #define IRQLatch cpu410x[0x1]	/* accc cccc, a = 0, AD12 switching, a = 1, HSYNC switching */
 
 /* MMC3 Registers */
-static uint8 inv_hack = 0;		/* some OneBus Systems have swapped PRG reg commans in MMC3 inplementation,
-								 * trying to autodetect unusual behavior, due not to add a new mapper.
-								 */
 #define mmc3cmd  cpu410x[0x5]	/* pcv- ----, p - program swap, c - video swap, v - internal VRAM enable */
 #define mirror   cpu410x[0x6]	/* ---- ---m, m = 0 - H, m = 1 - V */
 
@@ -79,8 +78,8 @@ static void PSync(void) {
 	uint8 bank2  = (cpu410x[0xb] & 0x40)?(cpu410x[0x9]):(~1);
 	uint8 bank3  = ~0;
 #endif
-	uint8 bank0 = cpu410x[0x7 ^ inv_hack];
-	uint8 bank1 = cpu410x[0x8 ^ inv_hack];
+	uint8 bank0 = cpu410x[0x7];
+	uint8 bank1 = cpu410x[0x8];
 	uint8 bank2 = (cpu410x[0xb] & 0x40) ? (cpu410x[0x9]) : (~1);
 	uint8 bank3 = ~0;
 
@@ -126,29 +125,91 @@ static void Sync(void) {
 	CSync();
 }
 
+static const uint8 cpuMangle[16][4] = {
+	{ 0, 1, 2, 3 }, 	// Submapper 0: Normal
+	{ 0, 1, 2, 3 }, 	// Submapper 1: Waixing VT03
+	{ 1, 0, 2, 3 }, 	// Submapper 2: Trump Grand
+	{ 0, 1, 2, 3 }, 	// Submapper 3: Zechess
+	{ 0, 1, 2, 3 }, 	// Submapper 4: Qishenglong
+	{ 0, 1, 2, 3 }, 	// Submapper 5: Waixing VT02
+	{ 0, 1, 2, 3 }, 	// Submapper 6: unused so far
+	{ 0, 1, 2, 3 }, 	// Submapper 7: unused so far
+	{ 0, 1, 2, 3 }, 	// Submapper 8: unused so far
+	{ 0, 1, 2, 3 }, 	// Submapper 9: unused so far
+	{ 0, 1, 2, 3 }, 	// Submapper A: unused so far
+	{ 0, 1, 2, 3 }, 	// Submapper B: unused so far
+	{ 0, 1, 2, 3 }, 	// Submapper C: unused so far
+	{ 0, 1, 2, 3 }, 	// Submapper D: Cube Tech (CPU opcode encryption only)
+	{ 0, 1, 2, 3 }, 	// Submapper E: Karaoto (CPU opcode encryption only)
+	{ 0, 1, 2, 3 }  	// Submapper F: Jungletac (CPU opcode encryption only)
+};
 static DECLFW(UNLOneBusWriteCPU410X) {
 /*	FCEU_printf("CPU %04x:%04x\n",A,V); */
-	switch (A & 0xf) {
+	A &=0xF;
+	switch (A) {
 	case 0x1: IRQLatch = V & 0xfe; break;	/* не по даташиту */
 	case 0x2: IRQReload = 1; break;
 	case 0x3: X6502_IRQEnd(FCEU_IQEXT); IRQa = 0; break;
 	case 0x4: IRQa = 1; break;
 	default:
-		cpu410x[A & 0xf] = V;
+		if (A >=0x7 && A <=0xA) A =0x7 +cpuMangle[submapper][A -0x7];
+		cpu410x[A] = V;
 		Sync();
 	}
 }
 
+static const uint8 ppuMangle[16][6] = {
+	{ 0, 1, 2, 3, 4, 5 }, 	// Submapper 0: Normal
+	{ 1, 0, 5, 4, 3, 2 }, 	// Submapper 1: Waixing VT03
+	{ 0, 1, 2, 3, 4, 5 }, 	// Submapper 2: Trump Grand
+	{ 5, 4, 3, 2, 0, 1 }, 	// Submapper 3: Zechess
+	{ 2, 5, 0, 4, 3, 1 }, 	// Submapper 4: Qishenglong
+	{ 1, 0, 5, 4, 3, 2 }, 	// Submapper 5: Waixing VT02
+	{ 0, 1, 2, 3, 4, 5 }, 	// Submapper 6: unused so far
+	{ 0, 1, 2, 3, 4, 5 }, 	// Submapper 7: unused so far
+	{ 0, 1, 2, 3, 4, 5 }, 	// Submapper 8: unused so far
+	{ 0, 1, 2, 3, 4, 5 }, 	// Submapper 9: unused so far
+	{ 0, 1, 2, 3, 4, 5 }, 	// Submapper A: unused so far
+	{ 0, 1, 2, 3, 4, 5 }, 	// Submapper B: unused so far
+	{ 0, 1, 2, 3, 4, 5 }, 	// Submapper C: unused so far
+	{ 0, 1, 2, 3, 4, 5 }, 	// Submapper D: Cube Tech (CPU opcode encryption only)
+	{ 0, 1, 2, 3, 4, 5 }, 	// Submapper E: Karaoto (CPU opcode encryption only)
+	{ 0, 1, 2, 3, 4, 5 }  	// Submapper F: Jungletac (CPU opcode encryption only)
+};
 static DECLFW(UNLOneBusWritePPU201X) {
 /*	FCEU_printf("PPU %04x:%04x\n",A,V); */
-	ppu201x[A & 0x0f] = V;
+	A &=0x0F;
+	if (A >=2 && A <=7) A =2 +ppuMangle[submapper][A -2];
+	ppu201x[A] = V;
 	Sync();
 }
 
+static const uint8 mmc3Mangle[16][8] = {
+	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	// Submapper 0: Normal
+	{ 5, 4, 3, 2, 1, 0, 6, 7 }, 	// Submapper 1: Waixing VT03
+	{ 0, 1, 2, 3, 4, 5, 7, 6 }, 	// Submapper 2: Trump Grand
+	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	// Submapper 3: Zechess
+	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	// Submapper 4: Qishenglong
+	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	// Submapper 5: Waixing VT02
+	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	// Submapper 6: unused so far
+	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	// Submapper 7: unused so far
+	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	// Submapper 8: unused so far
+	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	// Submapper 9: unused so far
+	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	// Submapper A: unused so far
+	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	// Submapper B: unused so far
+	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	// Submapper C: unused so far
+	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	// Submapper D: Cube Tech (CPU opcode encryption only)
+	{ 0, 1, 2, 3, 4, 5, 6, 7 }, 	// Submapper E: Karaoto (CPU opcode encryption only)
+	{ 0, 1, 2, 3, 4, 5, 6, 7 }  	// Submapper F: Jungletac (CPU opcode encryption only)
+};
 static DECLFW(UNLOneBusWriteMMC3) {
 /*	FCEU_printf("MMC %04x:%04x\n",A,V); */
 	switch (A & 0xe001) {
-	case 0x8000: mmc3cmd = (mmc3cmd & 0x38) | (V & 0xc7); Sync(); break;
+	case 0x8000: 
+		V =V &0xF8 | mmc3Mangle[submapper][V &0x07];
+		mmc3cmd = (mmc3cmd & 0x38) | (V & 0xc7);
+		Sync();
+		break;
 	case 0x8001:
 	{
 		switch (mmc3cmd & 7) {
@@ -301,9 +362,10 @@ void UNLOneBus_Init(CartInfo *info) {
 	info->Reset = UNLOneBusReset;
 	info->Close = UNLOneBus_Close;
 
-	if (((*(uint32*)&(info->MD5)) == 0x305fcdc3) ||	/* PowerJoy Supermax Carts */
-		((*(uint32*)&(info->MD5)) == 0x6abfce8e))
-		inv_hack = 0xf;
+	if (info->iNES2)
+		submapper =info->submapper;
+	else
+		submapper =(((*(uint32*)&(info->MD5)) == 0x305fcdc3) ||	((*(uint32*)&(info->MD5)) == 0x6abfce8e))? 2: 0; /* PowerJoy Supermax Carts */
 
 	GameHBIRQHook = UNLOneBusIRQHook;
 	MapIRQHook = UNLOneBusCpuHook;


### PR DESCRIPTION
Mapper 45: Add menu selection for carts that selectively connect unused address lines to PRG /CE. Only use outer bank bits that do not overlap with in-use inner bank bits, which is necessary for a few multicarts that put garbage values into those bits.
Mapper 256. Add support for scrambled registers chosen by the NES 2.0 submapper, retaining the CRC-based identification for two affected UNIF ROMs. Most ROM files using this mapper use VT03/VT09/VT369 graphics and so will still not work. Allow WRAM to be used, so that SMB3 can run.
Mapper 289: Correctly implement UNROM mode. Implement CHR-RAM write-protection.
Mapper 344: Previous emulation was for a badly-dumped ROM file. Accomodating it makes it impossible to support other properly-dumped multicarts that use this mapper.
Mapper 432: Newly-dumped carts use NROM-256 mode, and also use a different bit for solder pad reading.