### PR TITLE
Expose internal audio RF filter option

### DIFF
--- a/src/drivers/libretro/libretro.c
+++ b/src/drivers/libretro/libretro.c
@@ -1136,6 +1136,7 @@ static bool update_option_visibility(void)
          char options_list[][25] = {
             "fceumm_sndvolume",
             "fceumm_sndquality",
+            "fceumm_sndlowpass",
             "fceumm_swapduty",
             "fceumm_apu_1",
             "fceumm_apu_2",
@@ -1820,6 +1821,14 @@ static void check_variables(bool startup)
          sndquality = 2;
       if (sndquality != oldval)
          FCEUI_SetSoundQuality(sndquality);
+   }
+
+   var.key = "fceumm_sndlowpass";
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      int lowpass = (!strcmp(var.value, "enabled")) ? 1 : 0;
+      FCEUI_SetLowPass(lowpass);
    }
 
    var.key = "fceumm_sndvolume";

--- a/src/drivers/libretro/libretro_core_options.h
+++ b/src/drivers/libretro/libretro_core_options.h
@@ -21,7 +21,7 @@ extern "C" {
  ********************************
 */
 
-#define MAX_CORE_OPTIONS 35
+#define MAX_CORE_OPTIONS 36
 
 /* RETRO_LANGUAGE_ENGLISH */
 
@@ -253,6 +253,20 @@ struct retro_core_option_v2_definition option_defs[] = {
          { NULL, NULL },
       },
       "Low",
+   },
+   {
+      "fceumm_sndlowpass",
+      "Audio RF Filter",
+      NULL,
+      "Apply a low pass audio filter to simulate the 'muted' sound of the NES when connected to a television via the RF modulator.",
+      NULL,
+      "audio",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled",
    },
    {
       "fceumm_swapduty",

--- a/src/filter.h
+++ b/src/filter.h
@@ -4,6 +4,7 @@
 int32 NeoFilterSound(int32 *in, int32 *out, uint32 inlen, int32 *leftover);
 void MakeFilters(int32 rate);
 void SexyFilter(int32 *in, int32 *out, int32 count);
+void SexyFilter2(int32 *in, int32 count);
 
 extern int64 sexyfilter_acc1, sexyfilter_acc2;
 

--- a/src/sound.c
+++ b/src/sound.c
@@ -992,8 +992,8 @@ int FlushEmulateSound(void) {
 
 		SexyFilter(Wave, WaveFinal, end >> 4);
 
-		/* if (FSettings.lowpass)
-			SexyFilter2(WaveFinal, end >> 4); */
+		if (FSettings.lowpass)
+			SexyFilter2(WaveFinal, end >> 4);
 
 		if (end & 0xF)
 			Wave[0] = Wave[(end >> 4)];


### PR DESCRIPTION
The core already contains a low pass audio filter designed to recreate the 'muted' sound of the NES when connected to a television via the RF modulator - but for some reason this functionality is not enabled/exposed.

This PR simply wires it up to a new `Audio RF Filter` core option. When enabled, the (subjective) improvement in audio quality is quite dramatic. The filter has a negligible performance impact.

(This filter produces the effect discussed here: https://forums.libretro.com/t/lowpass-filtering-for-nes-rf/37258)