### PR TITLE
FDS: Permanently use new disk handling functions

### DIFF
--- a/src/fds.c
+++ b/src/fds.c
@@ -18,6 +18,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+/* dec-12-19                                    */
+/* 4024(w), 4025(w), 4031(r) by dink(fbneo)     */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -82,11 +85,6 @@ static uint8 writeskip;
 static int32 DiskPtr;
 static int32 DiskSeekIRQ;
 static uint8 SelectDisk, InDisk;
-
-/* dec-12-19                                    */
-/* 4024(w), 4025(w), 4031(r) by dink(fbneo)     */
-/* remove this and old code after testing phase */
-#define USE_DINK
 
 enum FDS_DiskBlockIDs {
 	DSK_INIT = 0,
@@ -166,7 +164,6 @@ static void FDSInit(void) {
 	InDisk = 0;
 	SelectDisk = 0;
 
-#ifdef USE_DINK
 	mapperFDS_control = 0;
 	mapperFDS_filesize = 0;
 	mapperFDS_block = 0;
@@ -174,7 +171,6 @@ static void FDSInit(void) {
 	mapperFDS_blocklen = 0;
 	mapperFDS_diskaddr = 0;
 	mapperFDS_diskaccess = 0;
-#endif
 }
 
 void FCEU_FDSInsert(int oride) {
@@ -243,25 +239,6 @@ static DECLFR(FDSRead4030) {
 	return ret;
 }
 
-#ifndef USE_DINK
-static DECLFR(FDSRead4031) {
-	static uint8 z = 0;
-	if (InDisk != 255) {
-		z = diskdata[InDisk][DiskPtr];
-		#ifdef FCEUDEF_DEBUGGER
-		if (!fceuindbg)
-		#endif
-		{
-			if (DiskPtr < 64999) DiskPtr++;
-			DiskSeekIRQ = 150;
-			X6502_IRQEnd(FCEU_IQEXT2);
-		}
-	}
-	return z;
-}
-
-#else /* USE_DISK */
-
 static DECLFR(FDSRead4031) {
 	uint8 ret = 0xff;
 
@@ -301,8 +278,6 @@ static DECLFR(FDSRead4031) {
 
 	return ret;
 }
-
-#endif /* USE_DINK */
 
 static DECLFR(FDSRead4032) {
 	uint8 ret;
@@ -348,18 +323,6 @@ static DECLFW(FDSWrite) {
 		}
 		break;
 	case 0x4024:
-#ifndef USE_DINK
-		if ((InDisk != 255) && !(FDSRegs[5] & 0x4) && (FDSRegs[3] & 0x1)) {
-			if (DiskPtr >= 0 && DiskPtr < 65500) {
-				if (writeskip)
-					writeskip--;
-				else if (DiskPtr >= 2) {
-					DiskWritten = 1;
-					diskdata[InDisk][DiskPtr - 2] = V;
-				}
-			}
-		}
-#else /* USE_DINK */
 		if (FDS_DISK_INSERTED && ~mapperFDS_control & 0x04) {
 
 			if (mapperFDS_diskaccess == 0) {
@@ -392,27 +355,8 @@ static DECLFW(FDSWrite) {
 			}
 
 		}
-#endif /* USE_DINK */
 		break;
 	case 0x4025:
-#ifndef USE_DINK
-		X6502_IRQEnd(FCEU_IQEXT2);
-		if (InDisk != 255) {
-			if (!(V & 0x40)) {
-				if ((FDSRegs[5] & 0x40) && !(V & 0x10)) {
-					DiskSeekIRQ = 200;
-					DiskPtr -= 2;
-				}
-				if (DiskPtr < 0) DiskPtr = 0;
-			}
-			if (!(V & 0x4)) writeskip = 2;
-			if (V & 2) {
-				DiskPtr = 0; DiskSeekIRQ = 200;
-			}
-			if (V & 0x40) DiskSeekIRQ = 200;
-		}
-		setmirror(((V >> 3) & 1) ^ 1);
-#else /* USE_DINK */
 		X6502_IRQEnd(FCEU_IQEXT2);
 		if (FDS_DISK_INSERTED) {
 			if (V & 0x40 && ~mapperFDS_control & 0x40) {
@@ -460,7 +404,6 @@ static DECLFW(FDSWrite) {
 		}
 		mapperFDS_control = V;
 		setmirror(((V >> 3) & 1) ^ 1);
-#endif /* USE_DINK */
 		break;
 	}
 	FDSRegs[A & 7] = V;
@@ -783,7 +726,7 @@ int FDSLoad(const char *name, FCEUFILE *fp) {
 	AddExState(&SelectDisk, 1, 0, "SELD");
 	AddExState(&InDisk, 1, 0, "INDI");
 	AddExState(&DiskWritten, 1, 0, "DSKW");
-#ifdef USE_DINK
+
 	AddExState(&mapperFDS_control, 1, 0, "CTRG");
 	AddExState(&mapperFDS_filesize, 2 | FCEUSTATE_RLSB, 1, "FLSZ");
 	AddExState(&mapperFDS_block, 1, 0, "BLCK");
@@ -791,7 +734,6 @@ int FDSLoad(const char *name, FCEUFILE *fp) {
 	AddExState(&mapperFDS_blocklen, 2 | FCEUSTATE_RLSB, 1, "BLKL");
 	AddExState(&mapperFDS_diskaddr, 2 | FCEUSTATE_RLSB, 1, "DADR");
 	AddExState(&mapperFDS_diskaccess, 1, 0, "DACC");
-#endif
 
 	CHRRAMSize = 8192;
 	CHRRAM = (uint8*)FCEU_gmalloc(CHRRAMSize);


### PR DESCRIPTION
FDS was already using the new disk handling code. This PR just removes
the old and now unused one.