### PR TITLE
Mapper 354: Add CHR RAM write-protection, fixes B-Wings

### DIFF
--- a/src/boards/354.c
+++ b/src/boards/354.c
@@ -58,6 +58,7 @@ static void Mapper354_Sync(void)
          setprg32(0x8000, prg >>1 |3);
          break;
    }
+   SetupCartCHRMapping(0, CHRptr[0], 0x2000, latchAddr &0x08? 0: 1);
    setchr8(0);
    setmirror(latchData &0x40? MI_H: MI_V);
 }


### PR DESCRIPTION
Mapper 354: Add CHR RAM write-protection, fixes B-Wings (issue #546)
