### PR TITLE
Updates to mappers 268, 351 and 422

### DIFF
--- a/src/boards/126-422-534.c
+++ b/src/boards/126-422-534.c
@@ -118,18 +118,27 @@ static DECLFW(writeWRAM) {
 		EXPREGS[A &3] =V;
 		FixMMC3PRG(MMC3_cmd);
 		FixMMC3CHR(MMC3_cmd);
-		mwrap(A000B); /* After 6001 or 6003 swite */
+		mwrap(A000B); /* After 6001 or 6003 write */
 	}
 }
 
+static DECLFW(MMC3_CMDWriteA) { /* In mmc3.c, MMC3_cmd is updated *after* FixMMC3PRG is called, but we need MMC3_cmd in wrapPRG, so work around this problem until the MMC3 core is properly rewritten to actually make sense. */
+	if ((A &0xE001) ==0x8000) {
+		MMC3_cmd =V;
+		FixMMC3PRG(MMC3_cmd);
+		FixMMC3CHR(MMC3_cmd);
+	} else
+		MMC3_CMDWrite(A, V);	
+}
+	
 static DECLFW(writeCart) {
 	if ((EXPREGS[3] &0x09) ==0x09) /* UNROM and ANROM modes treat all writes to $8000-$FFFF as if they were going to $8000-$9FFF */
-		MMC3_CMDWrite(0x8000 | (EXPREGS[3] &0x08? 1: A) &1, V); /* A0 substitution only looks at bit 3 of register 3 */
+		MMC3_CMDWriteA(0x8000 | (EXPREGS[3] &0x08? 1: A) &1, V); /* A0 substitution only looks at bit 3 of register 3 */
 	else
 	if (A >=0xC000)
 		MMC3_IRQWrite(A, V ^(invertC000? 0xFF: 0x00)); /* Mapper 534 inverts the MMC3 scanline counter reload value */
 	else
-		MMC3_CMDWrite(A, V);	
+		MMC3_CMDWriteA(A, V);	
 }
 
 static DECLFR(readPRG) {

--- a/src/boards/126-422-534.c
+++ b/src/boards/126-422-534.c
@@ -109,7 +109,7 @@ static void wrapMirroring(uint8 V) {
 static DECLFW(writeWRAM) {
 	CartBW(A, V);
 	if ((A &3) ==2) { /* CNROM Bank (D0-D3), Bank Enable (D4-D6) and Bank Enable Lock (D7) */
-		int latchMask =0xFF &~(EXPREGS[2] &0x80? 0x70: 0x00) &~(EXPREGS [2] >>3 &0x0E);
+		int latchMask =0xFF &~(EXPREGS[2] &0x80? 0xF0: 0x00) &~(EXPREGS [2] >>3 &0x0E);
 		EXPREGS[2] =EXPREGS[2] &~latchMask | V &latchMask;
 		FixMMC3CHR(MMC3_cmd);
 	} else

--- a/src/boards/268.c
+++ b/src/boards/268.c
@@ -85,6 +85,14 @@ static void Mapper268_CHRWrap(uint32 A, uint8 V) {
 	setchr1r(CHRRAM && EXPREGS[4] &0x01 && (V &0xFE) ==(EXPREGS[4] &0xFE)? 0x10: 0x00, A, V &chrMaskMMC3 | chrOffset | A >>10 &chrMaskGNROM);
 }
 
+void Mapper268_MirrorWrap(uint8 V) {
+	A000B =V;
+	if ((submapper &~1) ==10 && ~EXPREGS[0] &0x20)
+		setmirror(EXPREGS[0] &0x10? MI_1: MI_0);
+	else
+		setmirror(A000B &1? MI_H: MI_V);
+}
+
 static DECLFR(Mapper268_ReadWRAM) {
 	return A001B &0xA0? CartBR(A): X.DB;
 }
@@ -104,6 +112,7 @@ static DECLFW(Mapper268_WriteReg) {
 		EXPREGS[index] =V;
 		FixMMC3PRG(MMC3_cmd);
 		FixMMC3CHR(MMC3_cmd);
+		Mapper268_MirrorWrap(A000B);
 	}
 }
 
@@ -134,6 +143,7 @@ void Mapper268_Init(CartInfo *info) {
 	GenMMC3_Init(info, 512, 256, (info->PRGRamSize +info->PRGRamSaveSize) >>10, info->battery);
 	cwrap = Mapper268_CHRWrap;
 	pwrap = Mapper268_PRGWrap;
+	mwrap = Mapper268_MirrorWrap;
 	info->Power = Mapper268_Power;
 	info->Reset = Mapper268_Reset;
 	info->Close = Mapper268_close;

--- a/src/boards/351.c
+++ b/src/boards/351.c
@@ -185,7 +185,9 @@ static DECLFW(writeMMC1) {
 
 static DECLFW(writeVRC4) {
 	uint8 index;
-	A =A &0xF000 | (A &0x800? ((A &8? 1: 0) | (A &4? 2: 0)): ((A &4? 1: 0) | (A &8? 2: 0)));
+	if (~reg[2] &4) A =A &0xF800 | A >>1 &0x3FF; /* A2,A1 -> A1,A0 if 5002.2=1 */
+	A |=A >>2 &3; /* A3,A2 -> A1,A0 */
+	if (A &0x800) A =A >>1 &1 | A <<1 &2 | A &~3; /* A8==1 => Swap A1,A0 */
 	switch (A &0xF000) {
 	case 0x8000: case 0xA000:
 		VRC4_prg[A >>13 &1] =V;
@@ -216,7 +218,7 @@ static DECLFW(writeVRC4) {
 		}
 		break;
 	default:
-		index =(A -0xB000) >>11 | A >>1 &1;
+		index =(A -0xB000) >>11 &~1 | A >>1 &1;
 		if (A &1)
 			VRC4_chr[index] =VRC4_chr[index] & 0x0F | V <<4;
 		else


### PR DESCRIPTION
Mapper 268: Add submappers 10/11 for SuperUFO's "Battletoads & Double Dragon 45-in-1" multicart, which add a single-screen mirroring mode.
Mapper 351: Correct the emulation of "Wai Wai World 2" in VRC4 mode on the "Techline XB-F502" multicart, which uses yet another combination of VRC4 address bits.
Mapper 422: Fix an issue in CNROM modes seen on the "1998 4000000-in-1" and "3000000-in-1" multicarts due to an incorrect AND mask being applied. Also correct an issue with running Super Mario Bros. 3 due to a misunderstanding of the way that mmc3.c's emulation of the MMC3's index register actually works.