### PR TITLE
Adjust turbo logic so that when a button gets pressed, it delays this…

### DIFF
--- a/src/drivers/libretro/libretro.c
+++ b/src/drivers/libretro/libretro.c
@@ -2528,6 +2528,8 @@ static void FCEUD_UpdateInput(void)
    unsigned player, port;
    bool palette_prev = false;
    bool palette_next = false;
+   /* keeps track of button state for a number of frames */
+   static int turbo_button_state[4][2];
 
    poll_cb();
 
@@ -2637,8 +2639,15 @@ static void FCEUD_UpdateInput(void)
             {
                if (input_cb(player, RETRO_DEVICE_JOYPAD, 0, turbomap[i].retro) || input_cb(player, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3))
                {
-                  if (!turbo_button_toggle[player][i])
+                  if (!turbo_button_toggle[player][i]) {
+                     /* keep button state for 2 frames */
+                     turbo_button_state[player][i] = 2;
+                  }
+
+                  if (turbo_button_state[player][i]) {
+                     turbo_button_state[player][i]--;
                      input_buf |= turbomap[i].nes;
+                  }
                   turbo_button_toggle[player][i]++;
                   turbo_button_toggle[player][i] %= nes_input.turbo_delay + 1;
                }

--- a/src/drivers/libretro/libretro_core_options.h
+++ b/src/drivers/libretro/libretro_core_options.h
@@ -495,7 +495,7 @@ struct retro_core_option_v2_definition option_defs[] = {
       NULL,
       "input",
       {
-         { "1",  NULL },
+         /* { "1",  NULL }, */
          { "2",  NULL },
          { "3",  NULL },
          { "5",  NULL },


### PR DESCRIPTION
… state for 2 frames. Fix some games that requires certain frame count to read button states (Double Dragon, Xevious

Fix: https://github.com/libretro/libretro-fceumm/issues/620